### PR TITLE
New paste and mouse_input API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It will also install Neovim (if it is not installed) and command line launcher `
 
 Or you can download the most recent release from the [Releases](https://github.com/vv-vim/vv/releases/latest) page.
 
-You need Neovim to run VV. You can install it via Homebrew: `$ brew install neovim`. Or you can find Neovim installation instructions here: [https://github.com/neovim/neovim/wiki/Installing-Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim). Neovim version 0.3.4 and higher is required.
+You need Neovim to run VV. You can install it via Homebrew: `$ brew install neovim`. Or you can find Neovim installation instructions here: [https://github.com/neovim/neovim/wiki/Installing-Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim). Neovim version 0.4.0 and higher is required.
 
 ### Build manually
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "VV",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "1.7.3",
+  "version": "2.0.0",
   "private": true,
   "keywords": [
     "vim",
@@ -57,7 +57,8 @@
     "child_process": "^1.0.2",
     "electron-store": "^4.0",
     "lodash": "^4.17.15",
-    "msgpack-lite": "^0.1.26"
+    "msgpack-lite": "^0.1.26",
+    "semver": "^6.3.0"
   },
   "husky": {
     "hooks": {

--- a/src/main/checkNeovim.js
+++ b/src/main/checkNeovim.js
@@ -1,12 +1,18 @@
 import { app, dialog, shell } from 'electron';
+import semver from 'semver';
 import nvimVersion from './lib/nvimVersion';
+
+const REQUIRED_VERSION = '0.4.0';
 
 const checkNeovim = () => {
   const version = nvimVersion();
   if (!version) {
     const result = dialog.showMessageBox({
       message: 'Neovim is not installed',
-      detail: `VV requires Neovim. You can find Neovim installation instructions here:
+      detail: `VV requires Neovim. You can install it via Homebrew:
+brew install neovim
+
+Or you can find Neovim installation instructions here:
 https://github.com/neovim/neovim/wiki/Installing-Neovim
   `,
       defaultId: 0,
@@ -16,12 +22,16 @@ https://github.com/neovim/neovim/wiki/Installing-Neovim
       shell.openExternal('https://github.com/neovim/neovim/wiki/Installing-Neovim');
     }
     app.exit();
-  } else if (version.num < 3004) {
-    const v = `${version[0]}.${version[1]}.${version[2]}`;
+  } else if (semver.lt(version, REQUIRED_VERSION)) {
     const result = dialog.showMessageBox({
       message: 'Neovim is outdated',
-      detail: `VV requires Neovim version 0.3.4 and later. You have ${v}.
-You can run \`brew upgrade neovim\` if you used Homebrew to install it. Otherwise please check installation instructions here:
+      detail: `VV requires Neovim version ${REQUIRED_VERSION} and later.
+You have ${version}.
+
+If you installed Neovim via Homebrew, please run:
+brew upgrade neovim
+
+Otherwise please check installation instructions here:
 https://github.com/neovim/neovim/wiki/Installing-Neovim
   `,
       defaultId: 0,

--- a/src/main/lib/nvimVersion.js
+++ b/src/main/lib/nvimVersion.js
@@ -5,11 +5,11 @@ import shellEnv from './shellEnv';
 
 let version;
 
-// Get nvim version. For version 0.3.2 it will return [0, 3, 2, num: 3002].
-// If it fail for some reason, it will return null.
-// Result is cached in `version` variable to avoid extra calls.
+/**
+ * Get Neovim version string.
+ * */
 const nvimVersion = () => {
-  if (version) return version;
+  if (version !== undefined) return version;
 
   const env = shellEnv();
   try {
@@ -18,10 +18,9 @@ const nvimVersion = () => {
       env,
     });
     if (execResult) {
-      const match = execResult.match(/NVIM v(\d+)\.(\d+).(\d+)/);
+      const match = execResult.match(/NVIM v(\d+)\.(\d+).(\d+)(.*)/);
       if (match) {
-        version = [match[1], match[2], match[3]].map(m => parseInt(m, 10));
-        version.num = version.reduce((r, v) => r * 1000 + v, 0);
+        version = `${match[1]}.${match[2]}.${match[3]}${match[4]}`;
       }
     }
   } catch (e) {

--- a/src/main/nvim/api.js
+++ b/src/main/nvim/api.js
@@ -81,6 +81,7 @@ const api = ({ args, cwd }) => {
     uiAttach: commandFactory('ui_attach'),
     subscribe: commandFactory('subscribe'),
     getHlByName: commandFactory('get_hl_by_name'),
+    paste: commandFactory('paste'),
   };
 
   // Fetch current mode from nvim, leaves only first letter to match groups of modes.

--- a/src/main/nvim/features/copyPaste.js
+++ b/src/main/nvim/features/copyPaste.js
@@ -3,18 +3,9 @@ import { clipboard } from 'electron';
 import { getNvimByWindow } from '../nvimByWindow';
 
 export const pasteMenuItem = async (_item, win) => {
-  const clipboardText = clipboard.readText().replace(/</g, '<lt>');
   const nvim = getNvimByWindow(win);
-  const mode = await nvim.getShortMode();
-  if (mode === 'i') {
-    await nvim.command('set paste');
-    await nvim.input(clipboardText);
-    await nvim.command('set nopaste');
-  } else if (['n', 'v', 'V', 's', 'S'].includes(mode)) {
-    nvim.input('"*p');
-  } else {
-    nvim.input(clipboardText);
-  }
+  const clipboardText = clipboard.readText();
+  nvim.paste(clipboardText, true, -1);
 };
 
 export const copyMenuItem = async (_item, win) => {

--- a/src/renderer/nvim.js
+++ b/src/renderer/nvim.js
@@ -47,6 +47,7 @@ const nvim = {
   callFunction: commandFactory('call_function'),
   command: commandFactory('command'),
   input: commandFactory('input'),
+  inputMouse: commandFactory('input_mouse'),
   getMode: commandFactory('get_mode'),
   uiTryResize: commandFactory('ui_try_resize'),
   uiAttach: commandFactory('ui_attach'),


### PR DESCRIPTION
* Use `nvim_paste` API to paste text.
* Use `nvim_mouse_input` API for mouse events.
* Optimize scroll speed.
* Require Neovim ^0.4.0 to use this API, updated requirement.
* Bumped VV version to 2.0.0, as it is a breaking change.
* Use `semver` to compare versions.