### PR TITLE
Open file in existing window

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can setup VV-specific options via the `:VVset` command. It works the same as
 - `windowtop`, `top`: Window position top.
 - `quitoncloselastwindow`: Quit app on close last window. Default: `0`.
 - `autoupdateinterval`: Autoupdate interval in minutes. `0` — disable autoupdate. Default: `1440`, one day.
+- `openinproject`: Open file in existing VV instance if this file is located inside current directory of this instance. By default it will obey [`switchbuf`](https://neovim.io/doc/user/options.html#'switchbuf') option, but you can set `switchbuf` override as a value of this option, for example: `:VVset openinproject=newtab`. Possible values are: `1` use switchbuf, `0` open in new instance, any valid `switchbuf` value. Default: `1`.
 
 You can use these settings in your `init.vim` or change them any time. You can check if VV is loaded by checking the `g:vv` variable:
 

--- a/bin/openInProject.vim
+++ b/bin/openInProject.vim
@@ -34,3 +34,7 @@ function! VVopenInProjectLoud(fileName, switchbuf_override)
     let &switchbuf = l:original_switchbuf
   endif
 endfunction
+
+function! VVprojectRoot()
+  return getcwd()
+endfunction

--- a/bin/openInProject.vim
+++ b/bin/openInProject.vim
@@ -1,11 +1,36 @@
 " Opens file respecting switchbuf setting.
-function! VVopenInProject(fileName)
-  " Create temporary quickfix list with file we want to open
-  call setqflist([], ' ', { 'title': 'VV Temporary Quickfix' })
-  let l:id = getqflist({ 'id': 0 }).id
-  call setqflist([], 'r', { 'id': l:id, 'items': [{ 'filename': a:fileName }] })
+function! VVopenInProject(filename, ...)
+  " Take switch override from second parameter or from VV settings.
+  let l:switchbuf_override = get(a:, 1, VVsettingValue('openInProject'))
 
-  " Open this file and switch to previous quickfix list
+  silent call VVopenInProjectLoud(a:filename, l:switchbuf_override)
+endfunction
+
+function! VVopenInProjectLoud(fileName, switchbuf_override)
+  " Temporary override switchbuf if we have custom openInProject setting.
+  if type(a:switchbuf_override) == v:t_string && a:switchbuf_override != '0' && a:switchbuf_override != '1'
+    let l:original_switchbuf = &switchbuf
+    let &switchbuf = a:switchbuf_override
+  endif
+
+  " Create temporary quickfix list with file we want to open
+  if (!exists('g:vvOpenInProjectQfId') || getqflist({ 'id': 0 }).id != g:vvOpenInProjectQfId)
+    call setqflist([], ' ', { 'title': 'VV Temporary Quickfix' })
+    let g:vvOpenInProjectQfId = getqflist({ 'id': 0 }).id
+  end
+
+  " Add file to list and open it. It will be opened according to current switchbuf
+  " setting.
+  call setqflist([], 'r', { 'id': g:vvOpenInProjectQfId, 'items': [{ 'filename': a:fileName }] })
   cc! 1
-  silent colder
+
+  " Switch to previous quickfix list if there are other lists.
+  if getqflist({'nr' : 0 }).nr > 1
+    colder
+  end
+
+  " Rollback to original switchbuf option if needed.
+  if exists('l:original_switchbuf')
+    let &switchbuf = l:original_switchbuf
+  endif
 endfunction

--- a/bin/openInProject.vim
+++ b/bin/openInProject.vim
@@ -1,0 +1,11 @@
+" Opens file respecting switchbuf setting.
+function! VVopenInProject(fileName)
+  " Create temporary quickfix list with file we want to open
+  call setqflist([], ' ', { 'title': 'VV Temporary Quickfix' })
+  let l:id = getqflist({ 'id': 0 }).id
+  call setqflist([], 'r', { 'id': l:id, 'items': [{ 'filename': a:fileName }] })
+
+  " Open this file and switch to previous quickfix list
+  cc! 1
+  silent colder
+endfunction

--- a/bin/vv.vim
+++ b/bin/vv.vim
@@ -2,6 +2,7 @@ let g:vv = 1
 
 source <sfile>:h/vvset.vim
 source <sfile>:h/reloadChanged.vim
+source <sfile>:h/openInProject.vim
 
 set termguicolors
 

--- a/bin/vvset.vim
+++ b/bin/vvset.vim
@@ -25,7 +25,7 @@ let g:vv_default_settings = {
 \  'windowtop': v:null,
 \  'quitoncloselastwindow': 0,
 \  'autoupdateinterval': 1440,
-\  'experimentalOpenInProject': 0
+\  'openInProject': 0
 \}
 
 let g:vv_settings = deepcopy(g:vv_default_settings)
@@ -38,20 +38,32 @@ function! VVset(...)
   endfor
 endfunction
 
+function! VVsettingValue(name)
+  if has_key(g:vv_settings, a:name)
+    return g:vv_settings[a:name]
+  else
+    echoerr "Unknown option: ".a:name
+  endif
+endfunction
+
+function! VVsettingName(name)
+  if has_key(g:vv_settings_synonims, a:name)
+    return g:vv_settings_synonims[a:name]
+  else
+    return a:name
+  endif
+endfunction
+
 function! VVsetItem(name)
   if a:name == 'all'
     echo g:vv_settings
     return
   elseif a:name =~ '?'
-    let l:name = VVSettingName(split(a:name, '?')[0])
-    if has_key(g:vv_settings, l:name)
-      echo g:vv_settings[l:name]
-    else
-      echoerr "Unknown option: ".l:name
-    endif
+    let l:name = VVsettingName(split(a:name, '?')[0])
+    echo VVsettingValue(l:name)
     return
   elseif a:name =~ '&'
-    let l:name = VVSettingName(split(a:name, '&')[0])
+    let l:name = VVsettingName(split(a:name, '&')[0])
     if l:name == 'all'
       let g:vv_settings = deepcopy(g:vv_default_settings)
       call VVsettings()
@@ -64,22 +76,16 @@ function! VVsetItem(name)
     endif
   elseif a:name =~ '+='
     let l:split = split(a:name, '+=')
-    let l:name = VVSettingName(l:split[0])
-    if has_key(g:vv_settings, l:name)
-      let l:value = g:vv_settings[l:name] + l:split[1]
-    endif
+    let l:name = VVsettingName(l:split[0])
+    let l:value = VVsettingValue(l:name) + l:split[1]
   elseif a:name =~ '-='
     let l:split = split(a:name, '-=')
-    let l:name = VVSettingName(l:split[0])
-    if has_key(g:vv_settings, l:name)
-      let l:value = g:vv_settings[l:name] - l:split[1]
-    endif
+    let l:name = VVsettingName(l:split[0])
+    let l:value = VVsettingValue(l:name) - l:split[1]
   elseif a:name =~ '\^='
     let l:split = split(a:name, '\^=')
-    let l:name = VVSettingName(l:split[0])
-    if has_key(g:vv_settings, l:name)
-      let l:value = g:vv_settings[l:name] * l:split[1]
-    endif
+    let l:name = VVsettingName(l:split[0])
+    let l:value = VVsettingValue(l:name) * l:split[1]
   elseif a:name =~ '='
     let l:split = split(a:name, '=')
     let l:name = l:split[0]
@@ -89,22 +95,18 @@ function! VVsetItem(name)
     let l:name = l:split[0]
     let l:value = l:split[1]
   elseif a:name =~ '!'
-    let l:name = VVSettingName(split(a:name, '!')[0])
-    if has_key(g:vv_settings, l:name)
-      if g:vv_settings[l:name] == 0
-        let l:value = 1
-      else
-        let l:value = 0
-      end
+    let l:name = VVsettingName(split(a:name, '!')[0])
+    if VVsettingValue(l:name) == 0
+      let l:value = 1
+    else
+      let l:value = 0
     endif
   elseif a:name =~ '^inv'
-    let l:name = VVSettingName(strpart(a:name, 3))
-    if has_key(g:vv_settings, l:name)
-      if g:vv_settings[l:name] == 0
-        let l:value = 1
-      else
-        let l:value = 0
-      end
+    let l:name = VVsettingName(strpart(a:name, 3))
+    if VVsettingValue(l:name) == 0
+      let l:value = 1
+    else
+      let l:value = 0
     endif
   elseif a:name =~ '^no'
     let l:name = strpart(a:name, 2)
@@ -114,21 +116,13 @@ function! VVsetItem(name)
     let l:value = 1
   endif
 
-  let l:name = VVSettingName(l:name)
+  let l:name = VVsettingName(l:name)
 
   if has_key(g:vv_settings, l:name)
     let g:vv_settings[l:name] = l:value
     call rpcnotify(0, "vv:set", l:name, l:value)
   else
     echoerr "Unknown option: ".l:name
-  endif
-endfunction
-
-function! VVSettingName(name)
-  if has_key(g:vv_settings_synonims, a:name)
-    return g:vv_settings_synonims[a:name]
-  else
-    return a:name
   endif
 endfunction
 

--- a/bin/vvset.vim
+++ b/bin/vvset.vim
@@ -26,7 +26,7 @@ let g:vv_default_settings = {
 \  'windowtop': v:null,
 \  'quitoncloselastwindow': 0,
 \  'autoupdateinterval': 1440,
-\  'openInProject': 0
+\  'openInProject': 1
 \}
 
 let g:vv_settings = deepcopy(g:vv_default_settings)

--- a/bin/vvset.vim
+++ b/bin/vvset.vim
@@ -4,7 +4,8 @@ let g:vv_settings_synonims = {
 \  'width': 'windowwidth',
 \  'height': 'windowheight',
 \  'top': 'windowtop',
-\  'left': 'windowleft'
+\  'left': 'windowleft',
+\  'openinproject': 'openInProject'
 \}
 
 let g:vv_default_settings = {
@@ -39,8 +40,9 @@ function! VVset(...)
 endfunction
 
 function! VVsettingValue(name)
-  if has_key(g:vv_settings, a:name)
-    return g:vv_settings[a:name]
+  let l:name = VVsettingName(a:name)
+  if has_key(g:vv_settings, l:name)
+    return g:vv_settings[l:name]
   else
     echoerr "Unknown option: ".a:name
   endif

--- a/bin/vvset.vim
+++ b/bin/vvset.vim
@@ -1,31 +1,32 @@
 let g:vv_settings_synonims = {
-      \  'fu': 'fullscreen',
-      \  'sfu': 'simplefullscreen',
-      \  'width': 'windowwidth',
-      \  'height': 'windowheight',
-      \  'top': 'windowtop',
-      \  'left': 'windowleft'
-      \}
+\  'fu': 'fullscreen',
+\  'sfu': 'simplefullscreen',
+\  'width': 'windowwidth',
+\  'height': 'windowheight',
+\  'top': 'windowtop',
+\  'left': 'windowleft'
+\}
 
 let g:vv_default_settings = {
-      \  'fullscreen': 0,
-      \  'simplefullscreen': 1,
-      \  'bold': 1,
-      \  'italic': 1,
-      \  'underline': 1,
-      \  'undercurl': 1,
-      \  'fontfamily': 'monospace',
-      \  'fontsize': 12,
-      \  'lineheight': 1.25,
-      \  'letterspacing': 0,
-      \  'reloadchanged': 0,
-      \  'windowwidth': v:null,
-      \  'windowheight': v:null,
-      \  'windowleft': v:null,
-      \  'windowtop': v:null,
-      \  'quitoncloselastwindow': 0,
-      \  'autoupdateinterval': 1440
-      \}
+\  'fullscreen': 0,
+\  'simplefullscreen': 1,
+\  'bold': 1,
+\  'italic': 1,
+\  'underline': 1,
+\  'undercurl': 1,
+\  'fontfamily': 'monospace',
+\  'fontsize': 12,
+\  'lineheight': 1.25,
+\  'letterspacing': 0,
+\  'reloadchanged': 0,
+\  'windowwidth': v:null,
+\  'windowheight': v:null,
+\  'windowleft': v:null,
+\  'windowtop': v:null,
+\  'quitoncloselastwindow': 0,
+\  'autoupdateinterval': 1440,
+\  'experimentalOpenInProject': 0
+\}
 
 let g:vv_settings = deepcopy(g:vv_default_settings)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "VV",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "private": true,
   "keywords": [
     "vim",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -95,7 +95,7 @@ const createWindow = (originalArgs: string[] = [], newCwd?: string) => {
   const cwd = newCwd || process.cwd();
 
   const { args, files } = parseArgs(filterArgs(originalArgs));
-  const unopenedFiles = settings.experimentalOpenInProject
+  const unopenedFiles = settings.openInProject
     ? files.reduce<string[]>((result, fileName) => {
         const resolved = resolve(cwd, fileName);
         // @ts-ignore TODO: don't add custom props to win
@@ -104,7 +104,7 @@ const createWindow = (originalArgs: string[] = [], newCwd?: string) => {
           const nvim = getNvimByWindow(openInWindow);
           if (nvim) {
             // @ts-ignore TODO: don't add custom props to win
-            nvim.command(`e ${resolved.substring(openInWindow.cwd.length + 1)}`);
+            nvim.callFunction('VVopenInProject', [resolved.substring(openInWindow.cwd.length + 1)]);
             openInWindow.focus();
             return result;
           }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, dialog } from 'electron';
 import { statSync, existsSync } from 'fs';
-import { join /* , resolve */ } from 'path';
+import { join, resolve } from 'path';
 
 import menu from './menu';
 import installCli from './installCli';
@@ -8,13 +8,14 @@ import checkNeovim from './checkNeovim';
 
 import { setShouldQuit } from './nvim/features/quit';
 import { getSettings } from './nvim/settings';
+import { getNvimByWindow } from './nvim/nvimByWindow';
 
 import initAutoUpdate from './autoUpdate';
 
 import isDev from '../lib/isDev';
 
 import initNvim from './nvim/nvim';
-// import { argsFileNames } from './lib/args';
+import { parseArgs, joinArgs } from './lib/args';
 
 // import log from '../lib/log';
 
@@ -25,6 +26,9 @@ const windows: BrowserWindow[] = [];
 /** Empty windows created in advance to make windows creation faster */
 const emptyWindows: BrowserWindow[] = [];
 
+/**
+ * Remove VV specific arguments not supported by nvim
+ */
 const filterArgs = (args: string[]) => args.filter((a) => !['--inspect'].includes(a));
 
 const cliArgs = (args?: string[]) => (args || process.argv).slice(isDev(2, 1));
@@ -86,51 +90,59 @@ const getEmptyWindow = (): BrowserWindow => {
   return createEmptyWindow();
 };
 
-const createWindow = (args: string[] = [], newCwd?: string) => {
+const createWindow = (originalArgs: string[] = [], newCwd?: string) => {
   const cwd = newCwd || process.cwd();
 
-  // const fileNames = argsFileNames(args);
-  // fileNames.forEach(fileName => {
-  //   const resolved = resolve(cwd, fileName);
-  //   if (windows.find(w => filename.startsWith(w.cwd))) {
-  //   }
-  // });
+  const { args, files } = parseArgs(filterArgs(originalArgs));
+  const unopenedFiles = files.reduce<string[]>((result, fileName) => {
+    const resolved = resolve(cwd, fileName);
+    const openInWindow = windows.find((w) => resolved.startsWith(w.cwd));
+    if (openInWindow) {
+      const nvim = getNvimByWindow(openInWindow);
+      if (nvim) {
+        nvim.command(`e ${resolved}`);
+        openInWindow.focus();
+        return result;
+      }
+    }
+    return [...result, fileName];
+  }, []);
 
-  const win = getEmptyWindow();
+  if (files.length === 0 || unopenedFiles.length > 0) {
+    const win = getEmptyWindow();
 
-  // @ts-ignore TODO: don't add custom props to win
-  win.cwd = cwd;
+    // @ts-ignore TODO: don't add custom props to win
+    win.cwd = cwd;
 
-  if (currentWindow && !currentWindow.isFullScreen() && !currentWindow.isSimpleFullScreen()) {
-    const [x, y] = currentWindow.getPosition();
-    const [width, height] = currentWindow.getSize();
-    win.setBounds({ x: x + 20, y: y + 20, width, height }, false);
+    if (currentWindow && !currentWindow.isFullScreen() && !currentWindow.isSimpleFullScreen()) {
+      const [x, y] = currentWindow.getPosition();
+      const [width, height] = currentWindow.getSize();
+      win.setBounds({ x: x + 20, y: y + 20, width, height }, false);
+    }
+
+    initNvim({
+      args: joinArgs({ args, files: unopenedFiles }),
+      cwd,
+      win,
+    });
+
+    const initRenderer = () => win.webContents.send('initRenderer', getSettings());
+
+    if (win.webContents.isLoading()) {
+      win.webContents.on('did-finish-load', initRenderer);
+    } else {
+      initRenderer();
+    }
+
+    win.focus();
+    windows.push(win);
+
+    if (originalArgs.includes('--inspect')) openDeveloperTools(win);
+
+    setTimeout(() => emptyWindows.push(createEmptyWindow()), 1000);
+
+    initAutoUpdate({ win });
   }
-
-  initNvim({
-    args: filterArgs(args),
-    cwd,
-    win,
-  });
-
-  const initRenderer = () => win.webContents.send('initRenderer', getSettings());
-
-  if (win.webContents.isLoading()) {
-    win.webContents.on('did-finish-load', initRenderer);
-  } else {
-    initRenderer();
-  }
-
-  win.focus();
-  windows.push(win);
-
-  if (args.includes('--inspect')) openDeveloperTools(win);
-
-  setTimeout(() => emptyWindows.push(createEmptyWindow()), 1000);
-
-  initAutoUpdate({ win });
-
-  return win;
 };
 
 const openFileOrDir = (fileName: string) => {
@@ -151,55 +163,53 @@ const openFile = () => {
   }
 };
 
-let fileToOpen: string | undefined | null;
-app.on('will-finish-launching', () => {
-  app.on('open-file', (_e, file) => {
-    fileToOpen = file;
-  });
-});
+const gotTheLock = isDev(true, false) || app.requestSingleInstanceLock();
 
-app.on('ready', () => {
-  checkNeovim();
-  if (fileToOpen) {
-    openFileOrDir(fileToOpen);
-    fileToOpen = null;
-  } else {
-    createWindow(cliArgs());
-  }
-  menu({
-    createWindow,
-    openFile,
-    installCli: installCli(join(app.getAppPath(), '../bin/vv')),
-  });
-  app.on('open-file', (_e, file) => openFileOrDir(file));
-  app.focus();
-});
-
-app.on('before-quit', (e) => {
-  setShouldQuit(true);
-  const visibleWindows = windows.filter((w) => w.isVisible());
-  if (visibleWindows.length > 0) {
-    e.preventDefault();
-    (currentWindow || visibleWindows[0]).close();
-  }
-});
-
-app.on('window-all-closed', handleAllClosed);
-
-app.on('activate', (_e, hasVisibleWindows) => {
-  if (!hasVisibleWindows) {
-    createWindow();
-  }
-});
-
-if (!isDev(true, false)) {
-  const gotTheLock = app.requestSingleInstanceLock();
-
-  if (!gotTheLock) {
-    app.quit();
-  } else {
-    app.on('second-instance', (_e, args, cwd) => {
-      createWindow(cliArgs(args), cwd);
+if (!gotTheLock) {
+  app.quit();
+} else {
+  let fileToOpen: string | undefined | null;
+  app.on('will-finish-launching', () => {
+    app.on('open-file', (_e, file) => {
+      fileToOpen = file;
     });
-  }
+  });
+
+  app.on('ready', () => {
+    checkNeovim();
+    if (fileToOpen) {
+      openFileOrDir(fileToOpen);
+      fileToOpen = null;
+    } else {
+      createWindow(cliArgs());
+    }
+    menu({
+      createWindow,
+      openFile,
+      installCli: installCli(join(app.getAppPath(), '../bin/vv')),
+    });
+    app.on('open-file', (_e, file) => openFileOrDir(file));
+    app.focus();
+  });
+
+  app.on('second-instance', (_e, args, cwd) => {
+    createWindow(cliArgs(args), cwd);
+  });
+
+  app.on('before-quit', (e) => {
+    setShouldQuit(true);
+    const visibleWindows = windows.filter((w) => w.isVisible());
+    if (visibleWindows.length > 0) {
+      e.preventDefault();
+      (currentWindow || visibleWindows[0]).close();
+    }
+  });
+
+  app.on('window-all-closed', handleAllClosed);
+
+  app.on('activate', (_e, hasVisibleWindows) => {
+    if (!hasVisibleWindows) {
+      createWindow();
+    }
+  });
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -106,13 +106,11 @@ const createWindow = async (originalArgs: string[] = [], newCwd?: string) => {
     await Promise.all(
       windows.map(async (win) => {
         const nvim = getNvimByWindow(win);
-        if (!nvim) {
-          return Promise.resolve();
-        }
-        return nvim.callFunction('getcwd', []).then((c) => {
+        if (nvim) {
           // @ts-ignore TODO: don't add custom props to win
-          win.cwd = c; // eslint-disable-line
-        });
+          win.cwd = await nvim.callFunction('VVprojectRoot', []); // eslint-disable-line
+        }
+        return Promise.resolve();
       }),
     );
     unopenedFiles = files.reduce<string[]>((result, fileName) => {

--- a/src/main/lib/__tests__/args.test.ts
+++ b/src/main/lib/__tests__/args.test.ts
@@ -1,4 +1,4 @@
-import { parseArgs, joinArgs } from '../args';
+import { parseArgs, joinArgs, filterArgs, argValue } from '../args';
 
 describe('parseArgs', () => {
   test('return empty array if input is empty', () => {
@@ -62,5 +62,51 @@ describe('joinArgs', () => {
 
   test("don't add -- if files is empty", () => {
     expect(joinArgs({ args: ['arg1'], files: [] })).toEqual(['arg1']);
+  });
+});
+
+describe('filterArgs', () => {
+  test('returns all args if none of them are VV-specific', () => {
+    expect(filterArgs(['arg1', 'arg2'])).toEqual(['arg1', 'arg2']);
+  });
+
+  test('filters out --inspect', () => {
+    expect(filterArgs(['arg1', '--inspect', 'arg2'])).toEqual(['arg1', 'arg2']);
+    expect(filterArgs(['--inspect', 'arg1', 'arg2'])).toEqual(['arg1', 'arg2']);
+    expect(filterArgs(['arg1', 'arg2', '--inspect'])).toEqual(['arg1', 'arg2']);
+    expect(filterArgs(['--inspect'])).toEqual([]);
+  });
+
+  test('filters out --open-in-project with value', () => {
+    expect(filterArgs(['arg1', '--open-in-project', 'value', 'arg2'])).toEqual(['arg1', 'arg2']);
+    expect(filterArgs(['--open-in-project', 'value', 'arg1', 'arg2'])).toEqual(['arg1', 'arg2']);
+    expect(filterArgs(['arg1', 'arg2', '--open-in-project'])).toEqual(['arg1', 'arg2']);
+    expect(filterArgs(['--open-in-project'])).toEqual([]);
+    expect(filterArgs(['--open-in-project', 'value'])).toEqual([]);
+  });
+});
+
+describe('argValue', () => {
+  test('returns true if argument is present', () => {
+    expect(argValue(['--arg1', '--arg2'], '--arg1')).toBe(true);
+    expect(argValue(['--arg1', '--arg2', 'file1'], '--arg1')).toBe(true);
+    expect(argValue(['--arg1', '--arg2', '--', 'file1'], '--arg1')).toBe(true);
+  });
+
+  test('returns undefined if argument is not present', () => {
+    expect(argValue(['--arg1', '--arg2'], '--arg3')).toBeUndefined();
+    expect(argValue(['--arg1', '--', '--arg2'], '--arg2')).toBeUndefined();
+  });
+
+  test('returns value for argument with param', () => {
+    expect(argValue(['--arg1', '--cmd', 'cmdValue', '--arg2'], '--cmd')).toBe('cmdValue');
+    expect(argValue(['--cmd', 'cmdValue'], '--cmd')).toBe('cmdValue');
+    expect(argValue(['--cmd', 'cmdValue', 'file1'], '--cmd')).toBe('cmdValue');
+    expect(argValue(['--cmd', 'cmdValue', '--', '--cmd', 'invalid'], '--cmd')).toBe('cmdValue');
+  });
+
+  test('returns undefined invalid argument with param', () => {
+    expect(argValue(['--arg1', '--cmd'], '--cmd')).toBeUndefined();
+    expect(argValue(['--', '--cmd', 'cmdValue'], '--cmd')).toBeUndefined();
   });
 });

--- a/src/main/lib/__tests__/args.test.ts
+++ b/src/main/lib/__tests__/args.test.ts
@@ -1,31 +1,66 @@
-import { argsFileNames } from '../args';
+import { parseArgs, joinArgs } from '../args';
 
-describe('argsFileNames', () => {
+describe('parseArgs', () => {
   test('return empty array if input is empty', () => {
-    expect(argsFileNames([])).toEqual([]);
-    expect(argsFileNames()).toEqual([]);
+    expect(parseArgs([])).toEqual({ args: [], files: [] });
+    expect(parseArgs()).toEqual({ args: [], files: [] });
   });
 
   test('returns everything if there ar no params', () => {
-    expect(argsFileNames(['file1', 'file2'])).toEqual(['file1', 'file2']);
+    expect(parseArgs(['file1', 'file2'])).toEqual({
+      args: [],
+      files: ['file1', 'file2'],
+    });
   });
 
   test('returns everything after --', () => {
-    expect(argsFileNames(['before1', 'before2', '--', 'after1', 'after2'])).toEqual([
-      'after1',
-      'after2',
-    ]);
+    expect(parseArgs(['before1', 'before2', '--', 'after1', 'after2'])).toEqual({
+      args: ['before1', 'before2'],
+      files: ['after1', 'after2'],
+    });
   });
 
   test('skip params started with - or +', () => {
     ['-param1', '--param2', '+cmd1'].forEach((param) => {
-      expect(argsFileNames([param, 'file1', 'file2'])).toEqual(['file1', 'file2']);
+      expect(parseArgs([param, 'file1', 'file2'])).toEqual({
+        args: [param],
+        files: ['file1', 'file2'],
+      });
     });
   });
 
   test('skip params with argument', () => {
     ['--cmd', '-c', '-i', '-r', '-s', '-S', '-u', '--listen', '--startuptime'].forEach((param) => {
-      expect(argsFileNames([param, 'arg', 'file1', 'file2'])).toEqual(['file1', 'file2']);
+      expect(parseArgs([param, 'arg', 'file1', 'file2'])).toEqual({
+        args: [param, 'arg'],
+        files: ['file1', 'file2'],
+      });
     });
+  });
+
+  test('does not mutate arguments', () => {
+    const args = ['arg1', 'arg2'];
+    parseArgs(args);
+    expect(args).toEqual(['arg1', 'arg2']);
+  });
+});
+
+describe('joinArgs', () => {
+  test('joins args and files arrays and put -- between them', () => {
+    expect(joinArgs({ args: ['arg1', 'arg2'], files: ['file1', 'file2'] })).toEqual([
+      'arg1',
+      'arg2',
+      '--',
+      'file1',
+      'file2',
+    ]);
+  });
+
+  test("don't add -- if args is empty", () => {
+    expect(joinArgs({ args: [], files: ['file1', 'file2'] })).toEqual(['file1', 'file2']);
+  });
+
+  test("don't add -- if files is empty", () => {
+    expect(joinArgs({ args: ['arg1'], files: [] })).toEqual(['arg1']);
   });
 });

--- a/src/main/lib/args.ts
+++ b/src/main/lib/args.ts
@@ -1,20 +1,42 @@
 /**
- * Extract file names from the list of CLI arguments
+ * Parse CLI args and return the list of files and arguments.
  */
-export const argsFileNames = (args: string[] = []) => {
+export const parseArgs = (
+  originalArgs: string[] = [],
+): {
+  args: string[];
+  files: string[];
+} => {
+  const args = [...originalArgs];
+
   const filesSeparator = args.indexOf('--');
   if (filesSeparator !== -1) {
-    return args.splice(filesSeparator).splice(1);
+    return {
+      args: args.slice(0, filesSeparator),
+      files: args.slice(filesSeparator + 1),
+    };
   }
 
   const argsWithParam = ['--cmd', '-c', '-i', '-r', '-s', '-S', '-u', '--listen', '--startuptime'];
-  const fileNames: string[] = [];
+  const files: string[] = [];
   for (let i = args.length - 1; i >= 0; i -= 1) {
     if (['-', '+'].includes(args[i][0]) || (args[i - 1] && argsWithParam.includes(args[i - 1]))) {
       break;
     }
-    // @ts-ignore
-    fileNames.unshift(args.pop());
+    files.unshift(args.pop() as string);
   }
-  return fileNames;
+  return { args, files };
+};
+
+/**
+ * Join previously parsed args.
+ */
+export const joinArgs = ({ args, files }: { args: string[]; files: string[] }): string[] => {
+  if (args.length === 0) {
+    return files;
+  }
+  if (files.length === 0) {
+    return args;
+  }
+  return [...args, '--', ...files];
 };

--- a/src/main/lib/args.ts
+++ b/src/main/lib/args.ts
@@ -1,3 +1,23 @@
+import isDev from '../../lib/isDev';
+
+const ARGS_WITH_PARAM = [
+  '--cmd',
+  '-c',
+  '-i',
+  '-r',
+  '-s',
+  '-S',
+  '-u',
+  '--listen',
+  '--startuptime',
+  '--open-in-project',
+];
+
+/**
+ * Args specific to VV
+ */
+const VV_ARGS = ['--inspect', '--open-in-project'];
+
 /**
  * Parse CLI args and return the list of files and arguments.
  */
@@ -17,10 +37,9 @@ export const parseArgs = (
     };
   }
 
-  const argsWithParam = ['--cmd', '-c', '-i', '-r', '-s', '-S', '-u', '--listen', '--startuptime'];
   const files: string[] = [];
   for (let i = args.length - 1; i >= 0; i -= 1) {
-    if (['-', '+'].includes(args[i][0]) || (args[i - 1] && argsWithParam.includes(args[i - 1]))) {
+    if (['-', '+'].includes(args[i][0]) || (args[i - 1] && ARGS_WITH_PARAM.includes(args[i - 1]))) {
       break;
     }
     files.unshift(args.pop() as string);
@@ -40,3 +59,41 @@ export const joinArgs = ({ args, files }: { args: string[]; files: string[] }): 
   }
   return [...args, '--', ...files];
 };
+
+/**
+ * Argument value.
+ * Returns true for argument that does not require argument if it is present.
+ * Returns argument param for argumenst with params (for example --cmd).
+ * Undefined if param is not present.
+ */
+export const argValue = (originalArgs: string[], argName: string): string | true | undefined => {
+  const { args } = parseArgs(originalArgs);
+  const index = args.indexOf(argName);
+  if (index === -1) {
+    return undefined;
+  }
+  if (ARGS_WITH_PARAM.includes(argName)) {
+    return args[index + 1];
+  }
+  return true;
+};
+
+/**
+ * Remove VV specific arguments not supported by nvim
+ */
+export const filterArgs = (args: string[]): string[] =>
+  args.reduce<string[]>((result, a, i) => {
+    if (VV_ARGS.includes(a)) {
+      return result;
+    }
+    if (args[i - 1] && VV_ARGS.includes(args[i - 1]) && ARGS_WITH_PARAM.includes(args[i - 1])) {
+      return result;
+    }
+    return [...result, a];
+  }, []);
+
+/**
+ * Get CLI arguments
+ */
+export const cliArgs = (args?: string[]): string[] | undefined =>
+  (args || process.argv).slice(isDev(2, 1));

--- a/src/main/lib/store.ts
+++ b/src/main/lib/store.ts
@@ -16,6 +16,10 @@ export type Settings = {
   reloadchanged: BooleanSetting;
   quitoncloselastwindow: BooleanSetting;
   autoupdateinterval: string; // TODO: number
+  /**
+   * WIP for https://github.com/vv-vim/vv/issues/36
+   */
+  experimentalOpenInProject: BooleanSetting;
 };
 
 type StoreData = {

--- a/src/main/lib/store.ts
+++ b/src/main/lib/store.ts
@@ -16,9 +16,6 @@ export type Settings = {
   reloadchanged: BooleanSetting;
   quitoncloselastwindow: BooleanSetting;
   autoupdateinterval: string; // TODO: number
-  /**
-   * WIP for https://github.com/vv-vim/vv/issues/36
-   */
   openInProject: BooleanSetting;
 };
 

--- a/src/main/lib/store.ts
+++ b/src/main/lib/store.ts
@@ -19,7 +19,7 @@ export type Settings = {
   /**
    * WIP for https://github.com/vv-vim/vv/issues/36
    */
-  experimentalOpenInProject: BooleanSetting;
+  openInProject: BooleanSetting;
 };
 
 type StoreData = {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -17,7 +17,7 @@ const createMenu = ({
   createWindow: () => void;
   openFile: MenuItemConstructorOptions['click'];
   installCli: MenuItemConstructorOptions['click'];
-}) => {
+}): void => {
   const menuTemplate: MenuItemConstructorOptions[] = [
     {
       label: 'VV',

--- a/src/main/nvim/features/quit.ts
+++ b/src/main/nvim/features/quit.ts
@@ -1,18 +1,26 @@
-// Handle close window routine
-import { dialog, app } from 'electron';
+/**
+ * Handle close window routine
+ */
 
-// If we want to quit app after closing window, shouldQuit is true.
-// This function is used in 'before-quit' event to switch to close app mode.
+import { dialog, app, BrowserWindow } from 'electron';
+import { Nvim } from '../api';
+
+/**
+ * If we want to quit app after closing window, shouldQuit is true.
+ * This function is used in 'before-quit' event to switch to close app mode.
+ */
 let shouldQuit = false;
 
-export const setShouldQuit = (newShouldQuit) => {
+export const setShouldQuit = (newShouldQuit: boolean): void => {
   shouldQuit = newShouldQuit;
 };
 
-// Show Save All dialog if there are any unsaved buffers.
-// Cancel quit on cancel.
-const showCloseDialog = async ({ nvim, win }) => {
-  const unsavedBuffers = await nvim.callFunction('VVunsavedBuffers', []);
+/**
+ * Show Save All dialog if there are any unsaved buffers.
+ * Cancel quit on cancel.
+ */
+const showCloseDialog = async ({ nvim, win }: { nvim: Nvim; win: BrowserWindow }) => {
+  const unsavedBuffers: Array<{ name: string }> = await nvim.callFunction('VVunsavedBuffers', []);
   if (unsavedBuffers.length === 0) {
     nvim.command('qa');
   } else {
@@ -33,22 +41,22 @@ const showCloseDialog = async ({ nvim, win }) => {
   }
 };
 
-const initQuit = ({ win, nvim }) => {
+const initQuit = ({ win, nvim }: { nvim: Nvim; win: BrowserWindow }): void => {
   let isConnected = true;
 
   // Close window if nvim process is closed.
-  nvim.on('disconnect', async () => {
+  nvim.on('disconnect', () => {
     // Disable fullscreen before close, otherwise it it will keep menu bar hidden after window
     // is closed.
-    await win.hide();
-    await win.setSimpleFullScreen(false);
+    win.hide();
+    win.setSimpleFullScreen(false);
 
     isConnected = false;
     win.close();
   });
 
   // If nvim process is not closed, show Save All dialog.
-  win.on('close', async (e) => {
+  win.on('close', (e: Electron.Event) => {
     if (isConnected) {
       e.preventDefault();
       showCloseDialog({ win, nvim });

--- a/src/main/nvim/settings.ts
+++ b/src/main/nvim/settings.ts
@@ -22,7 +22,7 @@ const getDefaultSettings = (): Settings => ({
   reloadchanged: 0,
   quitoncloselastwindow: 0,
   autoupdateinterval: '1440', // One day, 60*24 minutes
-  experimentalOpenInProject: 0,
+  openInProject: 0,
 });
 
 let hasCustomConfig = false;

--- a/src/main/nvim/settings.ts
+++ b/src/main/nvim/settings.ts
@@ -22,6 +22,7 @@ const getDefaultSettings = (): Settings => ({
   reloadchanged: 0,
   quitoncloselastwindow: 0,
   autoupdateinterval: '1440', // One day, 60*24 minutes
+  experimentalOpenInProject: 0,
 });
 
 let hasCustomConfig = false;
@@ -29,7 +30,7 @@ let hasCustomConfig = false;
 /**
  * Get saved settings if we have them, default settings otherwise.
  * If you run app with -u flag, return default settings.
- * */
+ */
 export const getSettings = (): Settings => {
   if (hasCustomConfig) {
     return getDefaultSettings();
@@ -42,14 +43,22 @@ export const getSettings = (): Settings => {
 
 const onChangeSettingsCallbacks: Record<string, SettingsCallback[]> = {};
 
-export const onChangeSettings = (win: BrowserWindow, callback: SettingsCallback) => {
+export const onChangeSettings = (win: BrowserWindow, callback: SettingsCallback): void => {
   if (!onChangeSettingsCallbacks[win.webContents.id]) {
     onChangeSettingsCallbacks[win.webContents.id] = [];
   }
   onChangeSettingsCallbacks[win.webContents.id].push(callback);
 };
 
-const initSettings = ({ win, nvim, args }: { win: BrowserWindow; nvim: Nvim; args: string[] }) => {
+const initSettings = ({
+  win,
+  nvim,
+  args,
+}: {
+  win: BrowserWindow;
+  nvim: Nvim;
+  args: string[];
+}): void => {
   hasCustomConfig = args.indexOf('-u') !== -1;
   let initialSettings: Settings | null = getSettings();
   let settings = getDefaultSettings();


### PR DESCRIPTION
Open file in existing VV instance if the file is a part of already opened project as discussed in #36 .

If you already have VV instance and it has `:pwd` `~/apps/vv`, and you call `vv ~/apps/vv/src/main/index.ts`, it will open this file in the existing instance.

* You can turn it on or off by `:VVset openInProject=1` or `:VVset openInProject=0`. It is on by default.
* By default it will respect [`switchbuf`](https://neovim.io/doc/user/options.html#'switchbuf') setting. It will work the same as files opened from [quickfix](https://neovim.io/doc/user/quickfix.html) list. In fact it uses a temporary quickfix list to open files to mimic it's behavior.
* You can set custom options to override `switchbuf` setting by `:VVset openInProject=[switcbuf override]`, for example, `VVset openInProject=newtab`.
* Additionally you can override both of these using command line argument `--open-in-project`. For example: `vv --open-in-project false [filename]` to open in new VV instance, `vv --open-in-project newtab [filename]` to open file in new tab.
* When you open the file, it compares file name with nvim current directory (result of `:pwd`), so if you initially opened file from somewhere else, you can use pligins [vim-rooter](https://github.com/airblade/vim-rooter) or [vim-findroot](https://github.com/mattn/vim-findroot) or similar.

Fixes #36 