### PR TITLE
Extract main <-> renderer communication to a separate module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
         '@typescript-eslint/explicit-function-return-type': 'off',
         'import/prefer-default-export': 'off',
         'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
+        'import/no-unresolved': 'off', // TypeScript handles this
         'import/extensions': [
           'error',
           'ignorePackages',

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,4 +1,17 @@
 {
   "presets": ["@babel/preset-env", "@babel/preset-typescript"],
-  "plugins": ["@babel/plugin-proposal-optional-chaining"]
+  "plugins": [
+    "@babel/plugin-proposal-optional-chaining",
+    [
+      "module-resolver",
+      {
+        "root": ["."],
+        "alias": {
+          "@renderer": "./src/renderer",
+          "@main": "./src/main",
+          "@lib": "./src/lib"
+        }
+      }
+    ]
+  ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   clearMocks: true,
   coverageDirectory: 'coverage',
   testEnvironment: 'node',
+  collectCoverageFrom: ['src/**/*.{ts,js}'],
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^3.5.0",
     "babel-loader": "^8.1.0",
+    "babel-plugin-module-resolver": "^4.0.0",
     "chalk": "^4.1.0",
     "dotenv": "^8.2.0",
     "electron": "^9.0.5",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,8 @@ import { app, BrowserWindow, dialog } from 'electron';
 import { statSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
 
+import isDev from '@lib/isDev';
+
 import menu from './menu';
 import installCli from './installCli';
 import checkNeovim from './checkNeovim';
@@ -12,10 +14,10 @@ import { getNvimByWindow } from './nvim/nvimByWindow';
 
 import initAutoUpdate from './autoUpdate';
 
-import isDev from '../lib/isDev';
-
 import initNvim from './nvim/nvim';
 import { parseArgs, joinArgs, filterArgs, cliArgs, argValue } from './lib/args';
+
+import initTransport from './transport/transport';
 
 // import log from '../lib/log';
 
@@ -149,13 +151,16 @@ const createWindow = async (originalArgs: string[] = [], newCwd?: string) => {
       win.setBounds({ x: x + 20, y: y + 20, width, height }, false);
     }
 
+    const transport = initTransport(win);
+
     initNvim({
       args: joinArgs({ args, files: unopenedFiles }),
       cwd,
       win,
+      transport,
     });
 
-    const initRenderer = () => win.webContents.send('initRenderer', settings);
+    const initRenderer = () => transport.send('initRenderer', settings);
 
     if (win.webContents.isLoading()) {
       win.webContents.on('did-finish-load', initRenderer);

--- a/src/main/nvim/settings.ts
+++ b/src/main/nvim/settings.ts
@@ -1,10 +1,11 @@
 import debounce from 'lodash/debounce';
 import { BrowserWindow } from 'electron';
-import { Nvim } from './api';
 
-import store, { Settings } from '../lib/store';
+import { Nvim } from '@main/nvim/api';
 
-export { Settings } from '../lib/store';
+import store, { Settings } from '@main/lib/store';
+
+import { Transport } from '@main/transport/transport';
 
 export type SettingsCallback = (newSettings: Partial<Settings>, allSettings: Settings) => void;
 
@@ -54,10 +55,12 @@ const initSettings = ({
   win,
   nvim,
   args,
+  transport,
 }: {
   win: BrowserWindow;
   nvim: Nvim;
   args: string[];
+  transport: Transport;
 }): void => {
   hasCustomConfig = args.indexOf('-u') !== -1;
   let initialSettings: Settings | null = getSettings();
@@ -90,7 +93,7 @@ const initSettings = ({
     }
     store.set('lastSettings', settings);
 
-    win.webContents.send('updateSettings', newSettings, settings);
+    transport.send('updateSettings', newSettings, settings);
     if (onChangeSettingsCallbacks[win.webContents.id]) {
       onChangeSettingsCallbacks[win.webContents.id].forEach((c) => c(newSettings, settings));
     }

--- a/src/main/transport/__tests__/transport.test.ts
+++ b/src/main/transport/__tests__/transport.test.ts
@@ -1,0 +1,68 @@
+import { ipcMain, BrowserWindow } from 'electron';
+
+import initTransport from '../transport';
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    on: jest.fn(),
+  },
+}));
+
+describe('main transport', () => {
+  const send = jest.fn();
+
+  const win = ({
+    webContents: {
+      id: 'winId',
+      send,
+    },
+  } as unknown) as BrowserWindow;
+
+  const transport = initTransport(win);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('on', () => {
+    const listener = jest.fn();
+
+    test('calls ipcMain.on with channel prop', () => {
+      transport.on('test-channel', listener);
+      expect((ipcMain.on as jest.Mock).mock.calls[0][0]).toBe('test-channel');
+    });
+
+    test('calls listener if sender.id matches window id', () => {
+      transport.on('test-channel', listener);
+      const ipcListener = (ipcMain.on as jest.Mock).mock.calls[0][1];
+      ipcListener({ sender: { id: 'winId' } }, 'arg1', 'arg2');
+      expect(listener).toHaveBeenCalledWith('arg1', 'arg2');
+    });
+
+    test('does not call listener if sender.id does not match window id', () => {
+      transport.on('test-channel', listener);
+      const ipcListener = (ipcMain.on as jest.Mock).mock.calls[0][1];
+      ipcListener({ sender: { id: 'otherWinId' } }, 'arg1', 'arg2');
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('listener with not args', () => {
+      transport.on('test-channel', listener);
+      const ipcListener = (ipcMain.on as jest.Mock).mock.calls[0][1];
+      ipcListener({ sender: { id: 'winId' } });
+      expect(listener).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('send', () => {
+    test('pass args to win.webContents', () => {
+      transport.send('test-channel', 'arg1', 'arg2');
+      expect(send).toHaveBeenCalledWith('test-channel', 'arg1', 'arg2');
+    });
+
+    test('with no args', () => {
+      transport.send('test-channel');
+      expect(send).toHaveBeenCalledWith('test-channel');
+    });
+  });
+});

--- a/src/main/transport/transport.ts
+++ b/src/main/transport/transport.ts
@@ -1,0 +1,38 @@
+import { ipcMain, BrowserWindow } from 'electron';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Args = any[];
+
+type Listener = (...args: Args) => void;
+
+export type Transport = {
+  on: (channel: string, listener: Listener) => void;
+  send: (channel: string, ...args: Args) => void;
+};
+
+/**
+ * Transport between main and renderer.
+ * This is WIP. Adding this abstraction on top of ipcMain to be able to switch to websockets or smth
+ * for server mode.
+ */
+const transport = (win: BrowserWindow): Transport => ({
+  /**
+   * Receive message from renderer.
+   */
+  on: (channel, listener) => {
+    ipcMain.on(channel, ({ sender: { id } }, ...args) => {
+      if (id === win.webContents.id) {
+        listener(...args);
+      }
+    });
+  },
+
+  /**
+   * Send message to renderer.
+   */
+  send: (channel, ...args) => {
+    win.webContents.send(channel, ...args);
+  },
+});
+
+export default transport;

--- a/src/renderer/__tests__/renderer.test.ts
+++ b/src/renderer/__tests__/renderer.test.ts
@@ -1,0 +1,61 @@
+import renderer from '@renderer/renderer';
+
+import { initNvim } from '@renderer/nvim';
+import initScreen from '@renderer/screen';
+import initKeyboard from '@renderer/input/keyboard';
+import initMouse from '@renderer/input/mouse';
+import hideMouseCursor from '@renderer/features/hideMouseCursor';
+
+const mockTransport = {
+  on: jest.fn(),
+};
+jest.mock('@renderer/transport/transport', () => () => mockTransport);
+
+jest.mock('@renderer/nvim', () => ({
+  initNvim: jest.fn(),
+}));
+jest.mock('@renderer/screen', () => jest.fn());
+jest.mock('@renderer/input/keyboard', () => jest.fn());
+jest.mock('@renderer/input/mouse', () => jest.fn());
+jest.mock('@renderer/features/hideMouseCursor', () => jest.fn());
+
+describe('renderer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('adds initRenderer event to transport', () => {
+    renderer();
+    expect(mockTransport.on.mock.calls[0][0]).toBe('initRenderer');
+  });
+
+  test('init screen', () => {
+    renderer();
+    mockTransport.on.mock.calls[0][1]('settings');
+    expect(initScreen).toHaveBeenCalledWith({ settings: 'settings', transport: mockTransport });
+  });
+
+  test('init nvim', () => {
+    renderer();
+    mockTransport.on.mock.calls[0][1]('settings');
+    expect(initNvim).toHaveBeenCalledWith(mockTransport);
+  });
+
+  test('init keyboard', () => {
+    renderer();
+    mockTransport.on.mock.calls[0][1]('settings');
+    expect(initKeyboard).toHaveBeenCalledWith();
+  });
+
+  test('init mouse', () => {
+    renderer();
+    mockTransport.on.mock.calls[0][1]('settings');
+    expect(initMouse).toHaveBeenCalledWith();
+  });
+
+  test('init hideMouseCursor', () => {
+    renderer();
+    mockTransport.on.mock.calls[0][1]('settings');
+    expect(hideMouseCursor).toHaveBeenCalledWith();
+  });
+});

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,25 +1,3 @@
-// import log from '../lib/log';
+import renderer from '@renderer/renderer';
 
-import { IpcRendererEvent } from 'electron';
-
-import { initNvim } from './nvim';
-
-import initScreen from './screen';
-
-import initKeyboard from './input/keyboard';
-import initMouse from './input/mouse';
-import hideMouseCursor from './features/hideMouseCursor';
-
-import { ipcRenderer } from './preloaded/electron';
-
-import { Settings } from '../main/nvim/settings';
-
-const initRenderer = (_event: IpcRendererEvent, settings: Settings) => {
-  initNvim();
-  initScreen(settings);
-  initKeyboard();
-  initMouse();
-  hideMouseCursor();
-};
-
-ipcRenderer.on('initRenderer', initRenderer);
+renderer();

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,0 +1,26 @@
+// import log from '@lib/log';
+
+import { Settings } from '@main/lib/store';
+
+import initTransport from '@renderer/transport/transport';
+import { initNvim } from '@renderer/nvim';
+import initScreen from '@renderer/screen';
+import initKeyboard from '@renderer/input/keyboard';
+import initMouse from '@renderer/input/mouse';
+import hideMouseCursor from '@renderer/features/hideMouseCursor';
+
+const renderer = (): void => {
+  const transport = initTransport();
+
+  const initRenderer = (settings: Settings) => {
+    initNvim(transport);
+    initScreen({ settings, transport });
+    initKeyboard();
+    initMouse();
+    hideMouseCursor();
+  };
+
+  transport.on('initRenderer', initRenderer);
+};
+
+export default renderer;

--- a/src/renderer/screen.ts
+++ b/src/renderer/screen.ts
@@ -6,15 +6,15 @@ import throttle from 'lodash/throttle';
 import isFinite from 'lodash/isFinite';
 import isEqual from 'lodash/isEqual';
 
+import getColor from '@lib/getColor';
+import { Settings } from '@main/lib/store';
+
 import * as PIXI from './lib/pixi';
 
-import { Settings } from '../main/nvim/settings';
-
-import { remote, ipcRenderer } from './preloaded/electron';
+import { remote } from './preloaded/electron';
+import { Transport } from './transport/transport';
 
 import nvim from './nvim';
-
-import getColor from '../lib/getColor';
 
 // import log from './../lib/log';
 
@@ -797,10 +797,10 @@ initScreen();
 initCursor();
 setScale();
 
-const screen = (settings: Settings): void => {
+const screen = ({ settings, transport }: { settings: Settings; transport: Transport }): void => {
   nvim.on('redraw', redraw);
 
-  ipcRenderer.on('updateSettings', (_, s) => updateSettings(s));
+  transport.on('updateSettings', updateSettings);
   updateSettings(settings, true);
 
   uiAttach();

--- a/src/renderer/transport/__tests__/transport.test.ts
+++ b/src/renderer/transport/__tests__/transport.test.ts
@@ -1,0 +1,53 @@
+import { ipcRenderer } from '@renderer/preloaded/electron';
+
+import initTransport from '@renderer/transport/transport';
+
+jest.mock('@renderer/preloaded/electron', () => ({
+  ipcRenderer: {
+    on: jest.fn(),
+    send: jest.fn(),
+  },
+}));
+
+describe('main transport', () => {
+  const transport = initTransport();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('on', () => {
+    const listener = jest.fn();
+
+    test('calls ipcRenderer.on with channel prop', () => {
+      transport.on('test-channel', listener);
+      expect((ipcRenderer.on as jest.Mock).mock.calls[0][0]).toBe('test-channel');
+    });
+
+    test('calls listener', () => {
+      transport.on('test-channel', listener);
+      const ipcListener = (ipcRenderer.on as jest.Mock).mock.calls[0][1];
+      ipcListener('event', 'arg1', 'arg2');
+      expect(listener).toHaveBeenCalledWith('arg1', 'arg2');
+    });
+
+    test('listener with no args', () => {
+      transport.on('test-channel', listener);
+      const ipcListener = (ipcRenderer.on as jest.Mock).mock.calls[0][1];
+      ipcListener('event');
+      expect(listener).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('send', () => {
+    test('pass args to win.webContents', () => {
+      transport.send('test-channel', 'arg1', 'arg2');
+      expect(ipcRenderer.send).toHaveBeenCalledWith('test-channel', 'arg1', 'arg2');
+    });
+
+    test('with no args', () => {
+      transport.send('test-channel');
+      expect(ipcRenderer.send).toHaveBeenCalledWith('test-channel');
+    });
+  });
+});

--- a/src/renderer/transport/transport.ts
+++ b/src/renderer/transport/transport.ts
@@ -1,0 +1,38 @@
+import { IpcRendererEvent } from 'electron';
+
+import { ipcRenderer } from '@renderer/preloaded/electron';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Args = any[];
+
+type Listener = (...args: Args) => void;
+
+export type Transport = {
+  on: (channel: string, listener: Listener) => void;
+  send: (channel: string, ...args: Args) => void;
+};
+
+/**
+ * Transport between main and renderer.
+ * This is WIP. Adding this abstraction on top of ipcRenderer to be able to switch to websockets or smth
+ * for server mode.
+ */
+const transport = (): Transport => ({
+  /**
+   * Receive message from main.
+   */
+  on: (channel, listener) => {
+    ipcRenderer.on(channel, (_e: IpcRendererEvent, ...args) => {
+      listener(...args);
+    });
+  },
+
+  /**
+   * Send message to main.
+   */
+  send: (channel, ...args) => {
+    ipcRenderer.send(channel, ...args);
+  },
+});
+
+export default transport;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,13 @@
     "strict": true,
     "moduleResolution": "node",
     "sourceMap": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@renderer/*": ["src/renderer/*"],
+      "@main/*": ["src/main/*"],
+      "@lib/*": ["src/lib/*"]
+    }
   },
   "include": ["src", "@types"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2276,6 +2276,17 @@ babel-plugin-jest-hoist@^26.1.0:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-module-resolver@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.0.0.tgz#8f3a3d9d48287dc1d3b0d5595113adabd36a847f"
+  integrity sha512-3pdEq3PXALilSJ6dnC4wMWr0AZixHRM4utpdpBR9g5QG7B7JwWyukQv7a9hVxkbGFl+nQbrHDqqQOIBtTXTP/Q==
+  dependencies:
+    find-babel-config "^1.2.0"
+    glob "^7.1.6"
+    pkg-up "^3.1.0"
+    reselect "^4.0.0"
+    resolve "^1.13.1"
+
 babel-preset-current-node-syntax@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz#b4b547acddbf963cba555ba9f9cbbb70bfd044da"
@@ -4399,6 +4410,14 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-babel-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
+  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -6070,6 +6089,11 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -7321,7 +7345,7 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-up@^3.0.1:
+pkg-up@^3.0.1, pkg-up@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
@@ -7844,6 +7868,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Add abstraction on top of ipcRenderer/ipcMain to unify main <-> renderer communication. This may help adding alternative methods of renderer communication (for example WebSocket) to unlock run VV remotely in browser (#47).

Also did some refactoring and improvements:
* Add `@renderer`, `@main` and `@lib` module aliases to avoid deep relative imports.
* Added some tests.
* Minor eslint and jest tweaks.