### PR TITLE
Support strikethrough highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You can setup VV-specific options via the `:VVset` command. It works the same as
 - `italic'`: Allow italic. Default: `1`.
 - `underline`: Allow underline. Default: `1`.
 - `undercurl`: Allow undercurl. Default: `1`.
+- `strikethrough`: Allow strikethrough. Default: `1`.
 - `fontfamily`: Font family. Syntax is the same as CSS `font-family`. Default: `monospace`.
 - `fontsize`: Font size in pixels. Default: `12`.
 - `lineheight`: Line height related to font size. Pixel value is `fontsize * lineheight`. Default: `1.25`.

--- a/bin/vvset.vim
+++ b/bin/vvset.vim
@@ -15,6 +15,7 @@ let g:vv_default_settings = {
 \  'italic': 1,
 \  'underline': 1,
 \  'undercurl': 1,
+\  'strikethrough': 1,
 \  'fontfamily': 'monospace',
 \  'fontsize': 12,
 \  'lineheight': 1.25,

--- a/src/main/lib/store.ts
+++ b/src/main/lib/store.ts
@@ -9,6 +9,7 @@ export type Settings = {
   italic: BooleanSetting;
   underline: BooleanSetting;
   undercurl: BooleanSetting;
+  strikethrough: BooleanSetting;
   fontfamily: string;
   fontsize: string; // TODO: number
   lineheight: string; // TODO: number

--- a/src/main/nvim/settings.ts
+++ b/src/main/nvim/settings.ts
@@ -16,6 +16,7 @@ const getDefaultSettings = (): Settings => ({
   italic: 1,
   underline: 1,
   undercurl: 1,
+  strikethrough: 1,
   fontfamily: 'monospace',
   fontsize: '12',
   lineheight: '1.25',

--- a/src/server/nvim/settings.ts
+++ b/src/server/nvim/settings.ts
@@ -14,6 +14,7 @@ export const getDefaultSettings = (): Settings => ({
   italic: 1,
   underline: 1,
   undercurl: 1,
+  strikethrough: 1,
   fontfamily: 'monospace',
   fontsize: '12',
   lineheight: '1.25',


### PR DESCRIPTION
Support [strikethrough](https://github.com/neovim/neovim/blob/225f0bcd98dd8ff8cab964f13816dfdf327038ae/runtime/doc/syntax.txt#L4750) highlight GUI attribute.

You can test it with something like `hi Comment gui=strikethrough`. The line has text color and goes right in the middle of char.