### PR TITLE
Fix Option keyboard input

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
         'plugin:@typescript-eslint/recommended',
       ],
       rules: {
+        'prefer-destructuring': 'off',
         'no-console': 'error',
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vv",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "keywords": [
     "vim",
     "neovim",
@@ -20,6 +20,11 @@
   "scripts": {
     "bootstrap": "yarn; yarn build:browser-renderer",
     "build:browser-renderer": "yarn workspace @vvim/browser-renderer build",
+    "dev:browser-renderer": "yarn workspace @vvim/browser-renderer dev",
+    "dev:electron": "yarn workspace @vvim/electron dev",
+    "dev:server": "yarn workspace @vvim/server dev",
+    "dev": "npm-run-all --parallel dev:*",
+    "start:electron": "yarn workspace @vvim/electron start",
     "lint": "yarn eslint . --ext .js,.ts",
     "test": "yarn workspaces run test --reporters=\"default\" --reporters=\"jest-github-actions-reporter\"",
     "typecheck": "yarn workspaces run tsc"
@@ -35,6 +40,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.3.0",
     "lint-staged": "^10.4.2",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
     "typescript": "^4.0.3"
   },

--- a/packages/browser-renderer/package.json
+++ b/packages/browser-renderer/package.json
@@ -48,6 +48,7 @@
     "@types/ws": "^7.2.7",
     "jest": "^26.6.1",
     "jest-github-actions-reporter": "^1.0.2",
+    "jsdom": "^16.4.0",
     "npm-run-all": "^4.1.5",
     "pixi.js": "^5.3.3",
     "typescript": "^4.0.3"

--- a/packages/browser-renderer/src/__tests__/renderer.test.ts
+++ b/packages/browser-renderer/src/__tests__/renderer.test.ts
@@ -12,7 +12,7 @@ const mockTransport = {
 jest.mock('@renderer/transport/transport', () => () => mockTransport);
 
 jest.mock('@renderer/nvim', () => ({
-  initNvim: jest.fn(),
+  initNvim: jest.fn(() => 'fakeNvim'),
 }));
 jest.mock('@renderer/screen', () => jest.fn(() => 'fakeScreen'));
 jest.mock('@renderer/input/keyboard', () => jest.fn());
@@ -44,7 +44,7 @@ describe('renderer', () => {
   test('init keyboard', () => {
     renderer();
     mockTransport.on.mock.calls[0][1]('settings');
-    expect(initKeyboard).toHaveBeenCalledWith('fakeScreen');
+    expect(initKeyboard).toHaveBeenCalledWith({ nvim: 'fakeNvim', screen: 'fakeScreen' });
   });
 
   test('init mouse', () => {

--- a/packages/browser-renderer/src/input/__tests__/keyboard.test.ts
+++ b/packages/browser-renderer/src/input/__tests__/keyboard.test.ts
@@ -4,26 +4,203 @@
 
 import initKeyboard from '@renderer/input/keyboard';
 
-import nvim from '@renderer/nvim';
-
-jest.mock('@renderer/nvim', () => ({ on: jest.fn(), input: jest.fn() }));
+import { Nvim } from '@renderer/nvim';
+import { Screen } from '@renderer/screen';
 
 describe('Keyboard input', () => {
-  const screen = {
+  const nvimOn = jest.fn();
+
+  const screen = ({
     getCursorElement: jest.fn<HTMLDivElement, void[]>(),
-  };
+  } as unknown) as Screen;
+
+  const nvim = ({
+    input: jest.fn(),
+    on: nvimOn,
+  } as unknown) as Nvim;
 
   const simulateKeyDown = (options: KeyboardEventInit) => {
     const event = new KeyboardEvent('keydown', options);
     document.dispatchEvent(event);
   };
 
+  const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+
   beforeEach(() => {
-    initKeyboard(screen);
+    jest.clearAllMocks();
+    initKeyboard({ screen, nvim });
   });
 
-  test('ctrl key adds <C-*> modifier', () => {
-    simulateKeyDown({ key: 'a', ctrlKey: true });
-    expect(nvim.input).toHaveBeenCalledWith('<C-a>');
+  afterEach(() => {
+    const rootElm = document.documentElement;
+    rootElm.innerHTML = '<head></head><body></body>';
+    addEventListenerSpy.mock.calls.forEach(([event, callback, options]) =>
+      document.removeEventListener(event, callback, options),
+    );
+  });
+
+  describe('key input', () => {
+    test('sends key value to nvim input', () => {
+      simulateKeyDown({ key: 'i' });
+      expect(nvim.input).toHaveBeenCalledWith('i');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('special key', () => {
+      simulateKeyDown({ code: 'Insert' });
+      expect(nvim.input).toHaveBeenCalledWith('<Insert>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('special key with Shift', () => {
+      simulateKeyDown({ code: 'Insert', shiftKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<S-Insert>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('special key with modifier', () => {
+      simulateKeyDown({ code: 'Insert', altKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<A-Insert>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('< key', () => {
+      simulateKeyDown({ key: '<', shiftKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<lt>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('\\ key', () => {
+      simulateKeyDown({ key: '\\' });
+      expect(nvim.input).toHaveBeenCalledWith('<Bslash>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('| key', () => {
+      simulateKeyDown({ key: '|' });
+      expect(nvim.input).toHaveBeenCalledWith('<Bar>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test.todo('TODO: test all special keys');
+  });
+
+  describe('motifiers', () => {
+    test('CTRL key adds <C-*> modifier', () => {
+      simulateKeyDown({ key: 'i', ctrlKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<C-i>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('Option key adds <A-*> modifier', () => {
+      simulateKeyDown({ key: 'i', altKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<A-i>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('CMD key adds <D-*> modifier', () => {
+      simulateKeyDown({ key: 'i', metaKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<D-i>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('Shift key does not add modifier without other motifiers', () => {
+      simulateKeyDown({ key: 'I', shiftKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('I');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('Shift adds modifier with other motifiers', () => {
+      simulateKeyDown({ key: 'i', ctrlKey: true, shiftKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<C-S-i>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('multiple motifiers', () => {
+      simulateKeyDown({ key: 'i', ctrlKey: true, metaKey: true, altKey: true, shiftKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<D-A-C-S-i>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Option key modifier', () => {
+    test("Map Dead key with Option to it's latin value", () => {
+      simulateKeyDown({ key: 'Dead', code: 'KeyI', altKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<A-i>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    test('Skip Dead key if Option is not pressed', () => {
+      simulateKeyDown({ key: 'Dead', code: 'KeyI' });
+      expect(nvim.input).toHaveBeenCalledTimes(0);
+    });
+
+    test('Skip Dead key if there are no latin code for it', () => {
+      simulateKeyDown({ key: 'Dead', code: 'NotKeyI', altKey: true });
+      expect(nvim.input).toHaveBeenCalledTimes(0);
+    });
+
+    test('Adds A- modifier for non-Dead key', () => {
+      simulateKeyDown({ key: '∆', altKey: true });
+      expect(nvim.input).toHaveBeenCalledWith('<A-∆>');
+      expect(nvim.input).toHaveBeenCalledTimes(1);
+    });
+
+    describe('with input mode', () => {
+      beforeEach(() => {
+        nvimOn.mock.calls[0][1]([['mode_change', ['insert']]]);
+      });
+
+      test('Does not add A- modifier', () => {
+        simulateKeyDown({ key: '∆', code: 'KeyJ', altKey: true });
+        expect(nvim.input).toHaveBeenCalledWith('∆');
+        expect(nvim.input).toHaveBeenCalledTimes(1);
+      });
+
+      test('Does not add A- modifier with Shift', () => {
+        simulateKeyDown({ key: 'Ô', code: 'KeyJ', altKey: true, shiftKey: true });
+        expect(nvim.input).toHaveBeenCalledWith('Ô');
+        expect(nvim.input).toHaveBeenCalledTimes(1);
+      });
+
+      test('Adds A- modifier with Control', () => {
+        simulateKeyDown({ key: '∆', code: 'KeyJ', altKey: true, ctrlKey: true });
+        expect(nvim.input).toHaveBeenCalledWith('<A-C-∆>');
+        expect(nvim.input).toHaveBeenCalledTimes(1);
+      });
+
+      test('Adds A- modifier with Command', () => {
+        simulateKeyDown({ key: '∆', code: 'KeyJ', altKey: true, metaKey: true });
+        expect(nvim.input).toHaveBeenCalledWith('<D-A-∆>');
+        expect(nvim.input).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('focus input', () => {
+    let input: HTMLInputElement;
+    let focusSpy: jest.SpyInstance;
+    let blurSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      input = document.getElementsByTagName('input')[0];
+      focusSpy = jest.spyOn(input, 'focus');
+      blurSpy = jest.spyOn(input, 'blur');
+    });
+
+    test('focus input on insert mode', () => {
+      nvimOn.mock.calls[0][1]([['mode_change', ['insert']]]);
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
+    test('focus input on cmdline_normal mode', () => {
+      nvimOn.mock.calls[0][1]([['mode_change', ['cmdline_normal']]]);
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
+    test('blurs input on other modes', () => {
+      nvimOn.mock.calls[0][1]([['mode_change', ['normal']]]);
+      expect(blurSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/browser-renderer/src/nvim.ts
+++ b/packages/browser-renderer/src/nvim.ts
@@ -1,8 +1,28 @@
 // TODO: Refactor to use same API for main and renderer.
 
-import { Nvim } from '@renderer/types';
-
 import { Transport } from '@renderer/transport/types';
+
+export type NvimCommand<R extends any> = (...args: any[]) => Promise<R>;
+
+export type Nvim = {
+  on: (method: string, callback: (args: Array<[string, any[]]>) => void) => void;
+  off: (method: string, callback: () => void) => void;
+  send: (customId: number | null, command: string, ...params: any[]) => Promise<any>;
+
+  eval: NvimCommand<any>;
+  callFunction: NvimCommand<any>;
+  command: NvimCommand<any>;
+  input: NvimCommand<any>;
+  inputMouse: NvimCommand<any>;
+  getMode: NvimCommand<{ mode: string }>;
+  uiTryResize: NvimCommand<any>;
+  uiAttach: NvimCommand<any>;
+  subscribe: NvimCommand<any>;
+  getHlByName: NvimCommand<any>;
+  paste: NvimCommand<any>;
+
+  getShortMode: () => Promise<string>;
+};
 
 let transport: Transport;
 
@@ -82,7 +102,7 @@ const nvim: Partial<Nvim> = {
   },
 };
 
-export const initNvim = (newTransport: Transport): void => {
+export const initNvim = (newTransport: Transport): Nvim => {
   transport = newTransport;
   transport.on('nvim-data', ([type, ...params]) => {
     if (type === 1) {
@@ -91,6 +111,13 @@ export const initNvim = (newTransport: Transport): void => {
       subscriptions.forEach((c) => c(params[0], params[1]));
     }
   });
+  return {
+    on,
+    off,
+    subscribe,
+    send,
+    ...nvim,
+  } as Nvim;
 };
 
 export default {

--- a/packages/browser-renderer/src/renderer.ts
+++ b/packages/browser-renderer/src/renderer.ts
@@ -11,9 +11,9 @@ const renderer = (): void => {
   const transport = initTransport();
 
   const initRenderer = (settings: Settings) => {
-    initNvim(transport);
+    const nvim = initNvim(transport);
     const screen = initScreen({ settings, transport });
-    initKeyboard(screen);
+    initKeyboard({ nvim, screen });
     initMouse(screen);
     hideMouseCursor();
   };

--- a/packages/browser-renderer/src/screen.ts
+++ b/packages/browser-renderer/src/screen.ts
@@ -1,5 +1,4 @@
 // TODO: Refactor, Fix types.
-import type { DebouncedFunc } from 'lodash';
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 import isFinite from 'lodash/isFinite';
@@ -423,10 +422,7 @@ const screen = ({
     needRerender = true;
   };
 
-  let debouncedRepositionCursor: DebouncedFunc<(newCursor: [number, number]) => void>;
-
   const repositionCursor = (newCursor: [number, number]): void => {
-    if (debouncedRepositionCursor) debouncedRepositionCursor.cancel();
     if (newCursor) cursorPosition = newCursor;
     const left = cursorPosition[1] * charWidth;
     const top = cursorPosition[0] * charHeight;
@@ -434,8 +430,6 @@ const screen = ({
     cursorEl.style.transform = `translate(${left}px, ${top}px)`;
     redrawCursor();
   };
-
-  debouncedRepositionCursor = debounce(repositionCursor, 10);
 
   const optionSet = {
     guifont: (newFont: string) => {
@@ -721,6 +715,10 @@ const screen = ({
         }
       }
       needRerender = true;
+    },
+
+    win_viewport: () => {
+      // Why nvim sending it without ext_multigrid enabled?
     },
   };
 

--- a/packages/browser-renderer/src/types.ts
+++ b/packages/browser-renderer/src/types.ts
@@ -1,25 +1,3 @@
-export type NvimCommand<R extends any> = (...args: any[]) => Promise<R>;
-
-export type Nvim = {
-  on: (method: string, callback: (...p: any[]) => void) => void;
-  off: (method: string, callback: () => void) => void;
-  send: (customId: number | null, command: string, ...params: any[]) => Promise<any>;
-
-  eval: NvimCommand<any>;
-  callFunction: NvimCommand<any>;
-  command: NvimCommand<any>;
-  input: NvimCommand<any>;
-  inputMouse: NvimCommand<any>;
-  getMode: NvimCommand<{ mode: string }>;
-  uiTryResize: NvimCommand<any>;
-  uiAttach: NvimCommand<any>;
-  subscribe: NvimCommand<any>;
-  getHlByName: NvimCommand<any>;
-  paste: NvimCommand<any>;
-
-  getShortMode: () => Promise<string>;
-};
-
 type BooleanSetting = 0 | 1;
 
 export type Settings = {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,7 @@
     "webpack:prod": "webpack --config ./config/webpack.prod.config.js",
     "server:dev": "nodemon build/server.js",
     "server": "node build/server.js",
-    "dev": "npm-run-all --parallel build:watch server:dev",
+    "dev": "npm-run-all --parallel webpack:dev server:dev",
     "start": "npm-run-all clean webpack:prod server"
   },
   "devDependencies": {


### PR DESCRIPTION
Address #69

* In `insert` or `cmdline_normal` modes Option+key will send final character without modifier. For example, `Option + J` will print `∆`, with `Shift` it will be `Ô`.
* Same but with Control or Command modifiers will add all modifiers. For example, `Control + Option + J` will send `<D-A-∆>`.
* For all other modes, Option + key will work as before, it will add modifier with special character. `Option + J` will send `<A-∆>`.
* Fix for "Dead" combinations for composable symbols, it will send A- modifier with corresponding latin symbol. For example, in normal mode `Option + i` will send `<A-i>`, but `Option + j` will send `<A-∆>`.