### PR TITLE
Clean dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ci:lint": "yarn lint",
     "lint": "eslint . --ext .js,.ts",
     "test": "jest",
-    "typecheck": "yarn workspaces run tsc"
+    "typecheck": "tsc -p packages/browser-renderer; tsc -p packages/electron; tsc -p packages/server"
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",
@@ -39,9 +39,11 @@
     "@babel/plugin-proposal-optional-chaining": "^7.13.8",
     "@babel/preset-env": "^7.13.9",
     "@babel/preset-typescript": "^7.13.0",
+    "@types/jest": "^26.0.20",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "babel-jest": "^26.6.3",
+    "babel-loader": "^8.2.2",
     "babel-plugin-module-resolver": "^4.1.0",
     "eslint": "^7.21.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -50,11 +52,15 @@
     "eslint-plugin-jest": "^24.1.5",
     "eslint-plugin-prettier": "^3.3.1",
     "husky": "^4.3.0",
+    "jest": "^26.6.3",
     "jest-github-actions-reporter": "^1.0.3",
     "lint-staged": "^10.5.4",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "typescript": "^4.2.2"
+    "typescript": "^4.2.2",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.12",
+    "webpack-merge": "^4.1.2"
   },
   "husky": {
     "hooks": {

--- a/packages/browser-renderer/package.json
+++ b/packages/browser-renderer/package.json
@@ -37,20 +37,11 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.11",
-    "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.168",
-    "@types/msgpack-lite": "^0.1.7",
     "@types/node": "^14.14.31",
     "@types/ws": "^7.4.0",
-    "babel-loader": "^8.2.2",
-    "jest": "^26.6.3",
     "jsdom": "^16.4.0",
-    "npm-run-all": "^4.1.5",
-    "pixi.js": "^5.3.8",
-    "typescript": "^4.2.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.12",
-    "webpack-merge": "^4.1.2"
+    "pixi.js": "^5.3.8"
   },
   "dependencies": {
     "@pixi/app": "^5.3.8",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -38,22 +38,14 @@
     "@types/lodash": "^4.14.168",
     "@types/msgpack-lite": "^0.1.7",
     "@types/node": "^14.14.31",
-    "babel-loader": "^8.2.2",
     "chalk": "^4.1.0",
     "dotenv": "^8.2.0",
     "electron": "^11.3.0",
     "electron-builder": "^22.9.1",
     "electron-notarize": "^1.0.0",
     "html-webpack-plugin": "^4.3.0",
-    "jest": "^26.6.3",
     "js-yaml": "^3.14.0",
-    "node-fetch": "^2.6.1",
-    "nodemon": "^2.0.7",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^4.2.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.12",
-    "webpack-merge": "^4.1.2"
+    "node-fetch": "^2.6.1"
   },
   "dependencies": {
     "@vvim/browser-renderer": "0.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,21 +25,13 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.11",
-    "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.168",
     "@types/msgpack-lite": "^0.1.7",
     "@types/node": "^14.14.31",
     "@types/ws": "^7.4.0",
-    "babel-loader": "^8.2.2",
     "html-webpack-plugin": "^4.3.0",
-    "jest": "^26.6.3",
     "node-fetch": "^2.6.1",
-    "nodemon": "^2.0.7",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^4.2.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.12",
-    "webpack-merge": "^4.1.2"
+    "nodemon": "^2.0.7"
   },
   "dependencies": {
     "@vvim/browser-renderer": "0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,10 +1601,15 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5":
+"@types/json-schema@^7.0.3":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
+"@types/json-schema@^7.0.5":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -1649,9 +1654,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^2.0.0":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.1.tgz#374e31645d58cb18a07b3ecd8e9dede4deb2cccd"
-  integrity sha512-DxZZbyMAM9GWEzXL+BMZROWz9oo6A9EilwwOMET2UVu2uZTqMWS5S69KVtuVKaRjCUpcrOXRalet86/OpG4kqw==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.2.tgz#e2280c89ddcbeef340099d6968d8c86ba155fdf6"
+  integrity sha512-i99hy7Ki19EqVOl77WplDrvgNugHnsSjECVR/wUrzw2TJXz1zlUfT2ngGckR6xN7yFYaijsMAqPkOLx9HgUqHg==
 
 "@types/qs@*":
   version "6.9.5"


### PR DESCRIPTION
Clean package dependencies. Moved shared dev dependencies to root package.json.
Changed `yarn typecheck` to run from root `tsc` with `-p` parameter to have full path to files with errors in terminal for convenience. Will need to return to this later to make it support `--watch` flag.
