### PR TITLE
Fix cursor position in terminal mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vv",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "keywords": [
     "vim",
     "neovim",


### PR DESCRIPTION
Fix cursor position in terminal buffers. For some reason nvim does not send the very last cursor position in terminal buffers after redraw. If you send any command to nvim, it updates the cursor position. Added a temporary workaround, send `getMode` on `flush`. Need to investigate, it looks like a bug in nvim. I will file a ticket if it is.

Fixes #94
