### PR TITLE
Default monospace font

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can setup VV-specific options via the `:VVset` command. It works the same as
 - `underline`: Allow underline. Default: `1`.
 - `undercurl`: Allow undercurl. Default: `1`.
 - `strikethrough`: Allow strikethrough. Default: `1`.
-- `fontfamily`: Font family. Syntax is the same as CSS `font-family`. Default: `monospace`.
+- `fontfamily`: Font family. Syntax is the same as CSS [`font-family`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family). You can use comma-separated list of fonts. It will use first installed font in the list and fallback to default monospace font if none of them installed. Spaces should be excaped by `\`. For example: `:VVset fontfamily=Menlo,\ Courier\ New`. Default: `monospace`.
 - `fontsize`: Font size in pixels. Default: `12`.
 - `lineheight`: Line height related to font size. Pixel value is `fontsize * lineheight`. Default: `1.25`.
 - `letterspacing`: Fine-tuning letter spacing in retina pixels. Can be a negative value. For retina screens the value is physical pixels. For non-retina screens it works differently: it divides the value by 2 and rounds it. For example, `:VVset letterspacing=1` will make characters 1 pixel wider on retina displays and will do nothing on non-retina displays. Value 2 is 2 physical pixels on retina and 1 physical pixel on non-retina. Default: `0`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vv",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "keywords": [
     "vim",
     "neovim",

--- a/packages/browser-renderer/src/screen.ts
+++ b/packages/browser-renderer/src/screen.ts
@@ -75,6 +75,8 @@ type Char = {
   hlId?: number;
 };
 
+const DEFAULT_FONT_FAMILY = 'monospace';
+
 const screen = ({
   settings,
   transport,
@@ -100,7 +102,7 @@ const screen = ({
   let charWidth: number;
   let charHeight: number;
 
-  let fontFamily = 'monospace';
+  let fontFamily = DEFAULT_FONT_FAMILY;
   let fontSize = 12;
   let lineHeight = 1.25;
   let letterSpacing = 0;
@@ -464,7 +466,7 @@ const screen = ({
     guifont: (newFont: string) => {
       const [newFontFamily, newFontSize] = newFont.trim().split(':h');
       if (newFontFamily && newFontFamily !== '') {
-        nvim.command(`VVset fontfamily=${newFontFamily}`);
+        nvim.command(`VVset fontfamily=${newFontFamily.replace(/_/g, '\\ ')}`);
         if (newFontSize && newFontFamily !== '') {
           nvim.command(`VVset fontsize=${newFontSize}`);
         }
@@ -763,7 +765,7 @@ const screen = ({
 
   const handleSet = {
     fontfamily: (newFontFamily: string) => {
-      fontFamily = newFontFamily;
+      fontFamily = `${newFontFamily}, ${DEFAULT_FONT_FAMILY}`;
     },
 
     fontsize: (newFontSize: string) => {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@vvim/electron",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "keywords": [
     "vim",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@vvim/electron",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "keywords": [
     "vim",


### PR DESCRIPTION
Followup for #92
* Make `monospace` default font if none of `:VVset fontfamily` fonts are installed.
* Replace underscore `_` with space for font when you set `:set guifont=Font_With_Spaces`.
* Update readme for `:VVset fontfamily`
