### PR TITLE
Fix menu bar on simple fullscreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "vv",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.3",
   "keywords": [
     "vim",
     "neovim",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@vvim/electron",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "keywords": [
     "vim",

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -11,6 +11,7 @@ import checkNeovim from 'src/main/checkNeovim';
 import { setShouldQuit } from 'src/main/nvim/features/quit';
 import { getSettings } from 'src/main/nvim/settings';
 import { getNvimByWindow } from 'src/main/nvim/nvimByWindow';
+import SimpleFullScreenStatusBarFix from 'src/main/lib/SimpleFullScreenStatusBarFix';
 
 import initAutoUpdate from 'src/main/autoUpdate';
 
@@ -20,6 +21,8 @@ import { parseArgs, joinArgs, filterArgs, cliArgs, argValue } from 'src/main/lib
 import initTransport from 'src/main/transport/ipc';
 
 let currentWindow: BrowserWindow | undefined | null;
+
+let simpleFullScreenStatusBarFix: SimpleFullScreenStatusBarFix;
 
 const windows: BrowserWindow[] = [];
 
@@ -72,6 +75,8 @@ const createEmptyWindow = (isDebug = false) => {
   win.loadURL(
     process.env.DEV_SERVER ? 'http://localhost:3000' : `file://${join(__dirname, './index.html')}`,
   );
+
+  simpleFullScreenStatusBarFix.addWindow(win);
 
   return win;
 };
@@ -224,6 +229,9 @@ if (!gotTheLock) {
       installCli: installCli(join(app.getAppPath(), '../bin/vv')),
     });
     app.on('open-file', (_e, file) => openFileOrDir(file));
+
+    simpleFullScreenStatusBarFix = new SimpleFullScreenStatusBarFix();
+
     app.focus();
   });
 

--- a/packages/electron/src/main/lib/SimpleFullScreenStatusBarFix.ts
+++ b/packages/electron/src/main/lib/SimpleFullScreenStatusBarFix.ts
@@ -1,0 +1,21 @@
+import { BrowserWindow } from 'electron';
+
+/**
+ * When you have the window with simple fullscreen, then open a new window and switch back to the previous
+ * one, status bar stays on top of the fullscreen window and does not hide as it shoud do.
+ * This is a workaround to fix this bug. We have a hidden window, and when we focus on the window with
+ * simple fullscreen, we trigger setSimpleFullScreen on the hidden window and it fixes menu bar.
+ */
+class SimpleFullScreenStatusBarFix {
+  private sfsWindowFix: BrowserWindow;
+
+  constructor() {
+    this.sfsWindowFix = new BrowserWindow({ show: false });
+  }
+
+  addWindow(win: BrowserWindow): void {
+    win.on('focus', () => this.sfsWindowFix.setSimpleFullScreen(win.isSimpleFullScreen()));
+  }
+}
+
+export default SimpleFullScreenStatusBarFix;

--- a/packages/electron/src/main/lib/__tests__/SimpleFullScreenStatusBarFix.test.ts
+++ b/packages/electron/src/main/lib/__tests__/SimpleFullScreenStatusBarFix.test.ts
@@ -1,0 +1,48 @@
+import { BrowserWindow } from 'electron';
+import EventEmitter from 'events';
+
+import { mocked } from 'ts-jest/utils';
+
+import SimpleFullScreenStatusBarFix from 'src/main/lib/SimpleFullScreenStatusBarFix';
+
+jest.mock('electron', () => ({ BrowserWindow: jest.fn() }));
+
+class MockWindowEmitter extends EventEmitter {
+  isSfs: boolean;
+
+  constructor(isSfs: boolean) {
+    super();
+    this.isSfs = isSfs;
+  }
+
+  isSimpleFullScreen() {
+    return this.isSfs;
+  }
+}
+
+const asBrowserWindow = (b: unknown) => b as BrowserWindow;
+
+describe('SimpleFullScreenStatusBarFix', () => {
+  test('creates hidden browser window', () => {
+    new SimpleFullScreenStatusBarFix(); // eslint-disable-line no-new
+    expect(BrowserWindow).toHaveBeenCalledWith({ show: false });
+  });
+
+  test('calls setSimpleFullScreen for added windows', () => {
+    const setSimpleFullScreen = jest.fn();
+    mocked(BrowserWindow).mockImplementation(() => asBrowserWindow({ setSimpleFullScreen }));
+
+    const sfsFix = new SimpleFullScreenStatusBarFix();
+
+    const mockWindow1 = asBrowserWindow(new MockWindowEmitter(true));
+    const mockWindow2 = asBrowserWindow(new MockWindowEmitter(false));
+
+    sfsFix.addWindow(mockWindow1);
+    sfsFix.addWindow(mockWindow2);
+
+    mockWindow1.emit('focus');
+    mockWindow2.emit('focus');
+
+    expect(setSimpleFullScreen.mock.calls).toEqual([[true], [false]]);
+  });
+});


### PR DESCRIPTION
When you have the window with simple fullscreen, then open a new window and switch back to the previous one, status bar stays on top of the fullscreen window and does not hide as it shoud do.

This is a workaround to fix this bug. We have a hidden window, and when we focus on the window with simple fullscreen, we trigger setSimpleFullScreen on the hidden window and it fixes menu bar.

