### PR TITLE
Removed reloadchanged from docs, mark as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ VV is a Neovim client for macOS. A pure, fast, minimalistic Vim experience with 
 - Fast text render via WebGL.
 - OS integration: copy/paste, mouse, scroll.
 - Fullscreen support for native and simple (fast) mode.
-- All app settings configurable via vimscript.
+- All app settings configurable via Vimscript.
 - Command line launcher.
 - “Save All” dialog on quit and “Refresh” dialog on external changes.
 - Text zoom.
@@ -78,7 +78,6 @@ You can setup VV-specific options via the `:VVset` command. It works the same as
 - `fontsize`: Font size in pixels. Default: `12`.
 - `lineheight`: Line height related to font size. Pixel value is `fontsize * lineheight`. Default: `1.25`.
 - `letterspacing`: Fine-tuning letter spacing in retina pixels. Can be a negative value. For retina screens the value is physical pixels. For non-retina screens it works differently: it divides the value by 2 and rounds it. For example, `:VVset letterspacing=1` will make characters 1 pixel wider on retina displays and will do nothing on non-retina displays. Value 2 is 2 physical pixels on retina and 1 physical pixel on non-retina. Default: `0`.
-- `reloadchanged`: Show dialog when opened files are changed externally. For example, when you switch git branches. It will prompt you to keep your changes or reload the file. Default: `0`.
 - `windowwidth`, `width`: Window width. Can be a number in pixels or percentage of display width.
 - `windowheight`, `height`: Window height.
 - `windowleft`, `left`: Window position from left. Can be a number in pixels or a percentage. Percent values work the same as the `background-position` rule in CSS. For example: `25%` means that the vertical line on the window that is 25% from the left will be placed at the line that is 25% from the display's left. 0% — the very left, 100% — the very right, 50% — center.

--- a/packages/electron/bin/reloadChanged.vim
+++ b/packages/electron/bin/reloadChanged.vim
@@ -1,3 +1,4 @@
+" TODO: Remove on the next major version
 " Iterate on buffers and reload them from disk. No questions asked.
 " Do it in temporary tab to keep the same windows layout.
 function! VVrefresh(...)

--- a/packages/electron/src/main/nvim/features/reloadChanged.ts
+++ b/packages/electron/src/main/nvim/features/reloadChanged.ts
@@ -3,7 +3,17 @@ import { dialog, BrowserWindow } from 'electron';
 import type Nvim from '@vvim/nvim';
 
 /**
- * Show "Reload changed" dialog when opened files changed ouside (ex. switch git branch).
+ * Show dialog when opened files are changed externally. For example, when you switch git branches. It
+ * will prompt you to keep your changes or reload the file.
+ * Controlled by `:VVset reloadchanged` setting, off by default.
+ *
+ * Deprecated because this could be done via plugins and it was buggy anyway.
+ * If you miss this feature, you can use https://github.com/igorgladkoborodov/load-all.vim plugin, that
+ * does the same.
+ *
+ * TODO: remove on the next major version
+ *
+ * @deprecated
  */
 const initReloadChanged = ({ nvim, win }: { nvim: Nvim; win: BrowserWindow }): void => {
   type Buffer = {

--- a/packages/server/src/server/nvim/nvim.ts
+++ b/packages/server/src/server/nvim/nvim.ts
@@ -2,7 +2,6 @@
 // import quit from '@main/nvim/features/quit';
 // import windowTitle from '@main/nvim/features/windowTitle';
 // import zoom from '@main/nvim/features/zoom';
-// import reloadChanged from '@main/nvim/features/reloadChanged';
 // import windowSize from '@main/nvim/features/windowSize';
 // import focusAutocmd from '@main/nvim/features/focusAutocmd';
 


### PR DESCRIPTION
Removed `reloadchanged` from readme and marked it as deprecated.
This could be done via plugins and it was buggy anyway. If you miss this feature, you can use
(load-all.vim)[https://github.com/igorgladkoborodov/load-all.vim] plugin, that does the same.
