### PR TITLE
Refactor Nvim class to be an EventEmiter, simplify ipc transports

### DIFF
--- a/packages/browser-renderer/src/__tests__/renderer.test.ts
+++ b/packages/browser-renderer/src/__tests__/renderer.test.ts
@@ -17,7 +17,7 @@ jest.mock('src/input/mouse', () => jest.fn());
 jest.mock('src/features/hideMouseCursor', () => jest.fn());
 
 describe('renderer', () => {
-  const mockedNvim = Nvim as jest.Mock<Nvim>;
+  const mockedNvim = (Nvim as unknown) as jest.Mock<Nvim>;
 
   beforeEach(() => {
     mockTransport.removeAllListeners();

--- a/packages/browser-renderer/src/input/keyboard.ts
+++ b/packages/browser-renderer/src/input/keyboard.ts
@@ -1,4 +1,4 @@
-import type Nvim from '@vvim/nvim';
+import type { Nvim, UiEventsArgs } from '@vvim/nvim';
 import { Screen } from 'src/screen';
 
 // :help keyCode
@@ -200,7 +200,7 @@ const initKeyboard = ({ nvim, screen }: { nvim: Nvim; screen: Screen }): void =>
   // Enable composition input only for insert and command-line modes. Enabling if for other modes
   // is tricky. `preventDefault` does not work for compositionstart, so we need to blur/focus input
   // element for this.
-  nvim.on('redraw', (args) => {
+  nvim.on('redraw', (args: UiEventsArgs) => {
     args.forEach((arg) => {
       if (arg[0] === 'mode_change') {
         const [mode] = arg[1];

--- a/packages/electron/src/main/nvim/features/reloadChanged.ts
+++ b/packages/electron/src/main/nvim/features/reloadChanged.ts
@@ -72,7 +72,7 @@ const initReloadChanged = ({ nvim, win }: { nvim: Nvim; win: BrowserWindow }): v
     }
   };
 
-  nvim.on<[Buffer]>('vv:file_changed', ([buffer]) => {
+  nvim.on('vv:file_changed', ([buffer]: [Buffer]) => {
     if (enabled) {
       if (!changedBuffers[buffer.bufnr]) {
         changedBuffers[buffer.bufnr] = buffer;
@@ -81,7 +81,7 @@ const initReloadChanged = ({ nvim, win }: { nvim: Nvim; win: BrowserWindow }): v
     }
   });
 
-  nvim.on<[string, boolean]>('vv:set', ([option, isEnabled]) => {
+  nvim.on('vv:set', ([option, isEnabled]: [string, boolean]) => {
     if (option === 'reloadchanged') {
       enable(isEnabled);
     }

--- a/packages/electron/src/main/nvim/features/windowTitle.ts
+++ b/packages/electron/src/main/nvim/features/windowTitle.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import { BrowserWindow } from 'electron';
 
-import type Nvim from '@vvim/nvim';
+import type { Nvim, UiEventsArgs } from '@vvim/nvim';
 
 const initWindowTitle = ({ nvim, win }: { win: BrowserWindow; nvim: Nvim }): void => {
-  nvim.on('redraw', (args) => {
+  nvim.on('redraw', (args: UiEventsArgs) => {
     args.forEach((arg) => {
       if (arg[0] === 'set_title') {
         win.setTitle(arg[1][0]);
@@ -12,7 +12,7 @@ const initWindowTitle = ({ nvim, win }: { win: BrowserWindow; nvim: Nvim }): voi
     });
   });
 
-  nvim.on<[string]>('vv:filename', ([filename]) => {
+  nvim.on('vv:filename', ([filename]: [string]) => {
     if (fs.existsSync(filename)) {
       win.setRepresentedFilename(filename);
     }

--- a/packages/electron/src/main/nvim/settings.ts
+++ b/packages/electron/src/main/nvim/settings.ts
@@ -109,7 +109,7 @@ const initSettings = ({
     }
   };
 
-  nvim.on<[keyof Settings, Settings[keyof Settings]]>('vv:set', applySetting);
+  nvim.on('vv:set', applySetting);
 };
 
 export default initSettings;

--- a/packages/electron/src/main/transport/__tests__/ipc.test.ts
+++ b/packages/electron/src/main/transport/__tests__/ipc.test.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 import IpcTransport from 'src/main/transport/ipc';
 
 describe('main transport', () => {
-  const ipcMain = new EventEmitter() as IpcMain;
+  let ipcMain: IpcMain;
 
   const win = (Object.assign(new EventEmitter(), {
     id: 'winId',
@@ -17,6 +17,7 @@ describe('main transport', () => {
 
   beforeEach(() => {
     win.removeAllListeners();
+    ipcMain = new EventEmitter() as IpcMain;
     transport = new IpcTransport(win, ipcMain);
   });
 
@@ -24,71 +25,50 @@ describe('main transport', () => {
     const listener = jest.fn();
 
     test('calls listener if sender.id matches window id', () => {
-      transport.on('test-channel', listener);
-      ipcMain.emit('test-channel', { sender: { id: 'winId' } }, 'arg1', 'arg2');
+      transport.on('test-event', listener);
+      ipcMain.emit('test-event', { type: 'test-event', sender: { id: 'winId' } }, 'arg1', 'arg2');
       expect(listener).toHaveBeenCalledWith('arg1', 'arg2');
     });
 
     test('does not call listener if sender.id does not match window id', () => {
-      ipcMain.emit('test-channel', { sender: { id: 'otherWinId' } }, 'arg1', 'arg2');
+      transport.on('test-event', listener);
+      ipcMain.emit(
+        'test-event',
+        { type: 'test-event', sender: { id: 'otherWinId' } },
+        'arg1',
+        'arg2',
+      );
       expect(listener).not.toHaveBeenCalled();
     });
 
     test('listener with not args', () => {
-      ipcMain.emit('test-channel', { sender: { id: 'winId' } });
+      transport.on('test-event', listener);
+      ipcMain.emit('test-event', { type: 'test-event', sender: { id: 'winId' } });
       expect(listener).toHaveBeenCalledWith();
     });
 
     test('removes event listener on win `closed` event', () => {
-      transport.on('test-channel', listener);
+      transport.on('test-event', listener);
       jest.spyOn(ipcMain, 'removeListener');
       win.emit('closed');
-      expect(ipcMain.removeListener).toHaveBeenCalledWith('test-channel', expect.any(Function));
-    });
-
-    test('events order', () => {
-      const result: string[] = [];
-      transport.on('test-channel', () => {
-        result.push('event1');
-      });
-      transport.on('test-channel', () => {
-        result.push('event2');
-      });
-      transport.prependListener('test-channel', () => {
-        result.push('event3');
-      });
-      ipcMain.emit('test-channel', { sender: { id: 'winId' } });
-      expect(result).toEqual(['event3', 'event1', 'event2']);
-    });
-
-    test('once', () => {
-      const result: string[] = [];
-      transport.once('test-channel', () => {
-        result.push('event1');
-      });
-      transport.on('test-channel', () => {
-        result.push('event2');
-      });
-      ipcMain.emit('test-channel', { sender: { id: 'winId' } });
-      ipcMain.emit('test-channel', { sender: { id: 'winId' } });
-      expect(result).toEqual(['event1', 'event2', 'event2']);
+      expect(ipcMain.removeListener).toHaveBeenCalledWith('test-event', expect.any(Function));
     });
   });
 
   describe('send', () => {
     test('pass args to win.webContents', () => {
-      transport.send('test-channel', 'arg1', 'arg2');
-      expect(win.webContents.send).toHaveBeenCalledWith('test-channel', 'arg1', 'arg2');
+      transport.send('test-event', 'arg1', 'arg2');
+      expect(win.webContents.send).toHaveBeenCalledWith('test-event', 'arg1', 'arg2');
     });
 
     test('with no args', () => {
-      transport.send('test-channel');
-      expect(win.webContents.send).toHaveBeenCalledWith('test-channel');
+      transport.send('test-event');
+      expect(win.webContents.send).toHaveBeenCalledWith('test-event');
     });
 
     test('does not send anything if window is closed', () => {
       win.emit('closed');
-      transport.send('test-channel');
+      transport.send('test-event');
       expect(win.webContents.send).not.toHaveBeenCalled();
     });
   });

--- a/packages/server/src/server/nvim/settings.ts
+++ b/packages/server/src/server/nvim/settings.ts
@@ -96,7 +96,7 @@ const initSettings = ({
     }
   };
 
-  nvim.on<[keyof Settings, Settings[keyof Settings]]>('vv:set', applySetting);
+  nvim.on('vv:set', applySetting);
 };
 
 export default initSettings;


### PR DESCRIPTION
Refactor Nvim class to be an EventEmiter, simplify ipc transports
