### PR TITLE
Fix high CPU on Visual mode

### DIFF
--- a/packages/browser-renderer/src/screen.ts
+++ b/packages/browser-renderer/src/screen.ts
@@ -589,7 +589,9 @@ const screen = ({
       // position in terminal on redraw, but when you send any command to nvim, it redraws it correctly. Need to
       // investigate it and find a better permanent fix. Maybe this is a bug in nvim and then
       // TODO: file a ticket to nvim.
-      nvim.getMode();
+      if (mode === 'normal') {
+        nvim.getMode();
+      }
     },
 
     grid_resize: (props) => {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@vvim/electron",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "private": true,
   "keywords": [
     "vim",


### PR DESCRIPTION
Workaround for cursor position in terminal mode (#95) caused infinite `win_viewport` redraw call.
Fixes #117