### PR TITLE
Fix high CPU due to endless win_viewport loop

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@vvim/electron",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "private": true,
   "keywords": [
     "vim",


### PR DESCRIPTION
Fix infinite `win_viewport`, followup for #118 that was not enough to fix it.
Fix #117
