### PR TITLE
Added alternative homebrew path for nvim binary

### DIFF
--- a/packages/nvim/src/utils.ts
+++ b/packages/nvim/src/utils.ts
@@ -41,7 +41,7 @@ export const shellEnv = (proc = process): NodeJS.ProcessEnv => {
           }, {});
       } catch (e) {
         // Most likely nvim is here.
-        env.PATH = `/usr/local/bin:${env.PATH}`;
+        env.PATH = `/usr/local/bin:/opt/homebrew/bin:${env.PATH}`;
       }
     }
   }


### PR DESCRIPTION
The initial solution doesn't seem to detect my nvim on my Mac Pro M1 setup. See issue #130 

I haven't tested this yet, but I assume this would work seeing as `nvim` is available in that `PATH`.


<img width="434" alt="Screenshot 2022-01-24 at 8 10 12 PM" src="https://user-images.githubusercontent.com/3514405/150848306-ec6d308c-838c-4464-86bd-455ab4a26029.png">

