### PR TITLE
Fix Apple Silicon Homebrew default path for nvim binary

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@vvim/electron",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "private": true,
   "keywords": [
     "vim",

--- a/packages/nvim/src/__tests__/utils.test.ts
+++ b/packages/nvim/src/__tests__/utils.test.ts
@@ -38,7 +38,7 @@ describe('utils', () => {
         throw new Error();
       });
       expect(shellEnv(fakeProc({ PATH: 'some/path', key: 'val' }))).toEqual({
-        PATH: '/usr/local/bin:some/path',
+        PATH: '/usr/local/bin:/opt/homebrew/bin:some/path',
         key: 'val',
       });
     });

--- a/packages/nvim/src/utils.ts
+++ b/packages/nvim/src/utils.ts
@@ -40,8 +40,10 @@ export const shellEnv = (proc = process): NodeJS.ProcessEnv => {
             };
           }, {});
       } catch (e) {
-        // Most likely nvim is here.
-        env.PATH = `/usr/local/bin:${env.PATH}`;
+        // Most likely nvim is here:
+        // * `/usr/local/bin` Homebrew default bin path
+        // * `/opt/homebrew/bin` Homebrew bin path for Apple Silicon (https://docs.brew.sh/Installation)
+        env.PATH = `/usr/local/bin:/opt/homebrew/bin:${env.PATH}`;
       }
     }
   }


### PR DESCRIPTION
Add `/opt/homebrew/bin` to the fallback `env.PATH` for Apple Silicon Homebrew. (#130, #131)
