### PR TITLE
Make `:set columns`, `:set lines` and `:winsize` work

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@vvim/electron",
   "description": "Neovim GUI Client",
   "author": "Igor Gladkoborodov <igor.gladkoborodov@gmail.com>",
-  "version": "2.4.10",
+  "version": "2.5.0",
   "private": true,
   "keywords": [
     "vim",

--- a/packages/electron/src/main/nvim/features/__tests__/windowSize.test.ts
+++ b/packages/electron/src/main/nvim/features/__tests__/windowSize.test.ts
@@ -1,0 +1,65 @@
+import initWindowSize from 'src/main/nvim/features/windowSize';
+
+import { EventEmitter } from 'events';
+import type { Transport } from '@vvim/nvim';
+import type { BrowserWindow } from 'electron';
+
+describe('initWindowSize', () => {
+  describe('set-screen-width', () => {
+    const setContentSize = jest.fn();
+    const getContentSize = jest.fn();
+    const send = jest.fn();
+
+    // TODO: Come up with the better way to mock BrowserWindow
+    const win = ({
+      setContentSize,
+      getContentSize,
+      getBounds: () => {
+        /* empty */
+      },
+      setBounds: () => {
+        /* empty */
+      },
+      isFullScreen: () => false,
+      setSimpleFullScreen: () => {
+        /* empty */
+      },
+      webContents: {
+        focus: () => {
+          /* empty */
+        },
+      },
+    } as unknown) as BrowserWindow;
+
+    let transport: Transport;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      getContentSize.mockReturnValue([100, 200]);
+      transport = Object.assign(new EventEmitter(), {
+        send,
+      });
+    });
+
+    test('set window size on set-screen-width', () => {
+      initWindowSize({ transport, win });
+      transport.emit('set-screen-width', 150);
+      expect(setContentSize).toHaveBeenCalledWith(150, 200);
+    });
+
+    test('set window size on set-screen-height', () => {
+      initWindowSize({ transport, win });
+      getContentSize.mockReturnValueOnce([100, 200]).mockReturnValueOnce([100, 250]);
+      transport.emit('set-screen-height', 250);
+      expect(setContentSize).toHaveBeenCalledWith(100, 250);
+      expect(send).not.toHaveBeenCalledWith('force-resize');
+    });
+
+    test('send force-resize if window height is the same after resize', () => {
+      initWindowSize({ transport, win });
+      getContentSize.mockReturnValueOnce([100, 200]).mockReturnValueOnce([100, 200]);
+      transport.emit('set-screen-height', 250);
+      expect(send).toHaveBeenCalledWith('force-resize');
+    });
+  });
+});

--- a/packages/electron/src/main/nvim/nvim.ts
+++ b/packages/electron/src/main/nvim/nvim.ts
@@ -34,7 +34,7 @@ const initNvim = ({
   setNvimByWindow(win, nvim);
 
   initSettings({ win, nvim, args, transport });
-  windowSize({ win });
+  windowSize({ win, transport });
   quit({ win, nvim });
   windowTitle({ win, nvim });
   zoom({ win });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,17 +2075,17 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
 
 ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
Make `:set columns`, `:set lines` and `:winsize` work. The recommended way to set window size and position is still using `:VVset` command.

Fixes #139

**Test Plan**

* Try different `columns` option, for example: `:set columns=100`
* Try different `lines` option, for example: `:set lines=50`. Try to add too big or to small value.
* Try different `:winsize` command. For example: `:winsize 50 50`.
* Existing `:VVset` `windowtop`, `windowleft`, `windowheight`, `windowwidth`, `fullscreen` commands should work the same.
