### PR TITLE
Minimize bundle size by fixing lodash imports

### DIFF
--- a/packages/browser-renderer/src/lib/getColor.ts
+++ b/packages/browser-renderer/src/lib/getColor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize';
 
 /**
  * Get color by number, for example hex number `0xFF0000` becomes `rgb(255,0,0)`

--- a/packages/browser-renderer/src/screen.ts
+++ b/packages/browser-renderer/src/screen.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import emojiRegex from 'emoji-regex';
 

--- a/packages/browser-renderer/src/transport/ipc.ts
+++ b/packages/browser-renderer/src/transport/ipc.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize';
 
 import { ipcRenderer } from 'src/preloaded/electron';
 import type { PreloadedIpcRenderer } from 'src/preloaded/electron';

--- a/packages/electron/src/main/transport/ipc.ts
+++ b/packages/electron/src/main/transport/ipc.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import { EventEmitter } from 'events';
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize';
 
 import { Transport, Args } from '@vvim/nvim';
 

--- a/scripts/codegen.ts
+++ b/scripts/codegen.ts
@@ -4,7 +4,7 @@ import { spawn } from 'child_process';
 import { createDecodeStream, encode } from 'msgpack-lite';
 import { writeFileSync } from 'fs';
 import prettier from 'prettier';
-import { camelCase } from 'lodash';
+import camelCase from 'lodash/camelCase';
 
 const TYPES_FILE_NAME = 'packages/nvim/src/__generated__/types.ts';
 const CONST_FILE_NAME = 'packages/nvim/src/__generated__/constants.ts';


### PR DESCRIPTION
Change imports:
```typescript
import { memoize } from 'lodash';
```
to 
```typescript
import memoize from 'lodash/memoize';
```